### PR TITLE
Add delay for VPN usage

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -8,6 +8,9 @@
 # Author: @Lynx (OpenWrt forum)
 # Inspiration taken from: @moeller0 (OpenWrt forum)
 
+#Delay for interface up (e.g Wireguard/OpenVPN)
+sleep 15
+
 # *** OUTPUT OPTIONS ***
 
 output_processing_stats=1 # enable (1) or disable (0) output monitoring lines showing processing stats


### PR DESCRIPTION
Script exits with "cannot find ../statistics/tx_bytes" errors on boot in conjunction with a VPN.