### PR TITLE
Allow for older iputils ping

### DIFF
--- a/CAKE-autorate.sh
+++ b/CAKE-autorate.sh
@@ -138,7 +138,7 @@ monitor_reflector_path()
 	while read -r  timestamp _ _ _ reflector seq_rtt
 	do
 		# If no match then skip onto the next one
-		[[ $seq_rtt =~ icmp_seq=([0-9]+).*time=([0-9]+)\.?([0-9]+)?[[:space:]]ms ]] || continue
+		[[ $seq_rtt =~ icmp_[s|r]eq=([0-9]+).*time=([0-9]+)\.?([0-9]+)?[[:space:]]ms ]] || continue
 
 		seq=${BASH_REMATCH[1]}
 


### PR DESCRIPTION
Older iputils ping returns:
root@turris:~/CAKE-autorate# ping -c 1 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_req=1 ttl=58 time=9.66 ms

--- 1.1.1.1 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 9.666/9.666/9.666/0.000 ms

while more modern png returns:
user@work-horse:~/CODE/OpenWrtScripts$ ping -c 1 1.1.1.1
PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
64 bytes from 1.1.1.1: icmp_seq=1 ttl=57 time=9.93 ms

--- 1.1.1.1 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 9.929/9.929/9.929/0.000 ms

so icmp_req was changed into icmp_seq. To allow both versions of ping
make the parser indifferent to "s" and "r" in icmp_?eq.

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>