### PR TITLE
Change default x_range to all samples in the log

### DIFF
--- a/fn_parse_autorate_log.m
+++ b/fn_parse_autorate_log.m
@@ -67,7 +67,7 @@ function [ ] = fn_parse_autorate_log( log_FQN, plot_FQN )
 		% [20, length(autorate_log.DATA.LISTS.RECORD_TYPE)] skips the frist 20 values and display everything up to the last sample
 		x_range = [1, n_samples]; % equivalent with x_range = [];
 		x_range = [33000, 60000];
-		%x_range = [];
+		x_range = [];
 
 		% sanitize x_range
 		[x_range, do_return] = fn_sanitize_x_range(x_range, n_samples);


### PR DESCRIPTION
This avoids plotting nothing if the data has fewer samples then expected.

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>