### PR TITLE
Testing mod 20221220

### DIFF
--- a/cake-autorate_launcher.sh
+++ b/cake-autorate_launcher.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+
+$( type logger 2>&1 ) && use_logger=1 || use_logger=0	# only perform the test once...
+
 cake_instances=(/root/cake-autorate/cake-autorate_config*sh)
 
 trap kill_cake_instances INT TERM EXIT
@@ -7,9 +10,20 @@ trap kill_cake_instances INT TERM EXIT
 kill_cake_instances()
 {
 	trap - INT TERM EXIT
-	echo "Killing all instances of cake now."
-	kill ${cake_instance_pids[@]}
-	wait
+
+COUNT=0
+for cake_instance in "${cake_instances[@]}"
+do
+	echo "Killing all instances of cake one-by-one now:."
+	out_string="INFO: ${EPOCHREALTIME} terminating ${cake_instance_list[${COUNT}]}"
+	echo ${out_string}
+	# it is quite helpful to have a start marker per utorate instance in the system log
+	(( ${use_logger} )) && logger -t "cake-autorate_launcher" "${out_string}"
+	kill ${cake_instance_pids[${COUNT}]}
+	wait ${cake_instance_pids[${COUNT}]}
+	COUNT+=1
+done
+
 	exit
 }
 
@@ -17,8 +31,13 @@ cake_instance_pids=()
 
 for cake_instance in "${cake_instances[@]}"
 do
+	
+	# it is quite helpful to have a start marker per utorate instance in the system log
+	(( ${use_logger} )) && logger -t "cake-autorate_launcher" "INFO: ${EPOCHREALTIME} Launching cake-autorate with config ${cake_instance}"
+	
 	/root/cake-autorate/cake-autorate.sh $cake_instance&
 	cake_instance_pids+=($!)
+	cake_instance_list+=(${cake_instance})
 done
 
 sleep inf&

--- a/cake-autorate_launcher.sh
+++ b/cake-autorate_launcher.sh
@@ -23,7 +23,7 @@ do
 	wait ${cake_instance_pids[${COUNT}]}
 	COUNT+=1
 done
-
+	kill ${sleep_pid}
 	exit
 }
 
@@ -41,6 +41,6 @@ do
 done
 
 sleep inf&
-cake_instance_pids+=($!)
+sleep_pid+=($!)
 wait
 


### PR DESCRIPTION
So this is the version I am currently testing (I made some changes today so this needs a bit more baking).
Note I upped the verbosity of the launcher and switched to one-by-one termination (required for better verbosity).

While I consider your ERROR logging approach both elegant and opaque, I think the cmd_wrapper approach is more appropriate as for debugging I want to see both failure and success reports. Note how SILENCE_CMD can be used to toggle cmd_wrapper to demote expected errors to debug messages instead, still even when expected logging them seems helpful.

This is mainly intended to give you visibility on the "hack and slash" I submitted your code to, sorry ;)

This time I hope I got the intended branch....