### PR TITLE
Change the launcher to report start and termination per instance

### DIFF
--- a/cake-autorate_launcher.sh
+++ b/cake-autorate_launcher.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+
+$( type logger 2>&1 ) && use_logger=1 || use_logger=0	# only perform the test once...
+
 cake_instances=(/root/cake-autorate/cake-autorate_config*sh)
 
 trap kill_cake_instances INT TERM EXIT
@@ -7,9 +10,20 @@ trap kill_cake_instances INT TERM EXIT
 kill_cake_instances()
 {
 	trap - INT TERM EXIT
-	echo "Killing all instances of cake now."
-	kill ${cake_instance_pids[@]}
-	wait
+
+COUNT=0
+for cake_instance in "${cake_instances[@]}"
+do
+	echo "Killing all instances of cake one-by-one now:."
+	out_string="INFO: ${EPOCHREALTIME} terminating ${cake_instance_list[${COUNT}]}"
+	echo ${out_string}
+	# it is quite helpful to have a start marker per utorate instance in the system log
+	(( ${use_logger} )) && logger -t "cake-autorate_launcher" "${out_string}"
+	kill ${cake_instance_pids[${COUNT}]}
+	wait ${cake_instance_pids[${COUNT}]}
+	COUNT+=1
+done
+	kill ${sleep_pid}
 	exit
 }
 
@@ -17,11 +31,16 @@ cake_instance_pids=()
 
 for cake_instance in "${cake_instances[@]}"
 do
+	
+	# it is quite helpful to have a start marker per utorate instance in the system log
+	(( ${use_logger} )) && logger -t "cake-autorate_launcher" "INFO: ${EPOCHREALTIME} Launching cake-autorate with config ${cake_instance}"
+	
 	/root/cake-autorate/cake-autorate.sh $cake_instance&
 	cake_instance_pids+=($!)
+	cake_instance_list+=(${cake_instance})
 done
 
 sleep inf&
-cake_instance_pids+=($!)
+sleep_pid+=($!)
 wait
 


### PR DESCRIPTION
If multiple cake-autorate instances are used it helps to have some information about them starting and stopping.
So add this to the system log. Note this switches from bulk killing all instances to killing them on-by-one to disentangle their termination processes from each oher to some degree.

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>