### PR TITLE
Allow logging all DEBUG records to the system log

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -62,7 +62,7 @@ log_msg()
         
         [[ $type == "ERROR" ]] && (($use_logger)) && logger -t "cake-autorate" "$type: $log_timestamp $msg"
         
-	[[ $type == "SYSLOG_DEBUG" ]] && (($use_logger)) && logger -t "cake-autorate" "$type: $log_timestamp $msg"
+	(($log_DEBUG_messages_to_syslog)) && [[ $type == "DEBUG" ]] && (($use_logger)) && logger -t "cake-autorate" "$type: $log_timestamp $msg"
 }
 
 # Send message directly to log file wo/ log file rotation check (e.g. before maintain_log_file() is up)
@@ -80,7 +80,7 @@ log_msg_bypass_fifo()
 
         [[ $type == "ERROR" ]] && (($use_logger)) && logger -t "cake-autorate" "$type: $log_timestamp $msg"
         
-	[[ $type == "SYSLOG_DEBUG" ]] && (($use_logger)) && logger -t "cake-autorate" "$type: $log_timestamp $msg"
+	(($log_DEBUG_messages_to_sytlog)) && [[ $type == "DEBUG" ]] && (($use_logger)) && logger -t "cake-autorate" "$type: $log_timestamp $msg"
 }
 
 print_headers()

--- a/cake-autorate_config.primary.sh
+++ b/cake-autorate_config.primary.sh
@@ -11,11 +11,12 @@ cake_autorate_version="1.2.0"
 
 # *** OUTPUT AND LOGGING OPTIONS ***
 
-output_processing_stats=1 # enable (1) or disable (0) output monitoring lines showing processing stats
-output_load_stats=1       # enable (1) or disable (0) output monitoring lines showing achieved loads
-output_reflector_stats=1  # enable (1) or disable (0) output monitoring lines showing reflector stats
-output_cake_changes=0     # enable (1) or disable (0) output monitoring lines showing cake bandwidth changes
-debug=1 		  # enable (1) or disable (0) out of debug lines
+output_processing_stats=1 	# enable (1) or disable (0) output monitoring lines showing processing stats
+output_load_stats=1       	# enable (1) or disable (0) output monitoring lines showing achieved loads
+output_reflector_stats=1  	# enable (1) or disable (0) output monitoring lines showing reflector stats
+output_cake_changes=0     	# enable (1) or disable (0) output monitoring lines showing cake bandwidth changes
+debug=1 		  	# enable (1) or disable (0) out of debug lines
+log_DEBUG_messages_to_syslog=1	# enable (1) or disable (0) logging of all DEBUG records into the system log, Please note this can be a LOT of records so be careful
 
 # ** Take care with these settings to ensure you won't run into OOM issues on your router ***
 # every write the cumulative write time and bytes associated with each log line are checked


### PR DESCRIPTION
The new config file parameter log_DEBUG_messages_to_syslog allows to steer a copy of all DEBUG records (in addition to all ERROR records that by default are added to the log) into the system log file to ad in debugging. Note this can be a fire hose of entries so this should default to off (0)

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>