### PR TITLE
Add the instance ID to the syslog type argument

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -60,12 +60,12 @@ log_msg()
 		DEBUG)
 			[[ "${debug}" == "0" ]] && return # skip over DEBUG messages where debug disabled 
 			log_timestamp=${EPOCHREALTIME}
-			((${log_DEBUG_messages_to_syslog})) && ((${use_logger})) && logger -t "cake-autorate" "${type}: ${log_timestamp} ${msg}"
+			((${log_DEBUG_messages_to_syslog})) && ((${use_logger})) && logger -t "cake-autorate.${instance_id}" "${type}: ${log_timestamp} ${msg}"
 			;;
 	
         	ERROR)
 			log_timestamp=${EPOCHREALTIME}
-			((${use_logger})) && logger -t "cake-autorate" "${type}: ${log_timestamp} ${msg}"
+			((${use_logger})) && logger -t "cake-autorate.${instance_id}" "${type}: ${log_timestamp} ${msg}"
 			;;
 		*)
 			log_timestamp=${EPOCHREALTIME}


### PR DESCRIPTION
Messages look like:
Jan  8 11:54:21 turris cake-autorate.vdsl2: DEBUG: 1673178861.364126 maintain_pingers: Starting up...

instead of the previous:
Jan  8 11:54:21 turris cake-autorate: DEBUG: 1673178861.364126 maintain_pingers: Starting up...

this way system log messages for concurrent instances can be disambiguated.

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>