### PR TITLE
Syslog move start meassge after instance_id instantiation

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1211,7 +1211,6 @@ else
 	config_path=/root/cake-autorate/cake-autorate_config.primary.sh
 fi
 
-log_msg "SYSLOG" "Starting cake-autorate with config: ${config_path}"
 
 if [[ ! -f "${config_path}" ]]; then
 	log_msg "ERROR" "No config file found. Exiting now."
@@ -1232,6 +1231,8 @@ else
 	log_msg "ERROR" "Instance identifier 'X' set by cake-autorate_config.X.sh cannot be empty. Exiting now."
 	exit
 fi
+
+log_msg "SYSLOG" "Starting cake-autorate with config: ${config_path}"
 
 if [[ ! -z "${log_file_path_override}" ]]; then 
 	if [[ ! -d ${log_file_path_override} ]]; then

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -67,9 +67,14 @@ log_msg()
 			((log_DEBUG_messages_to_syslog)) && ((use_logger)) && logger -t "cake-autorate.${instance_id}" "${type}: ${log_timestamp} ${msg}"
 			;;
 	
-        	ERROR|SYSLOG)
+        	ERROR)
 			log_timestamp=${EPOCHREALTIME}
 			((use_logger)) && logger -t "cake-autorate.${instance_id}" "${type}: ${log_timestamp} ${msg}"
+			;;
+
+        	SYSLOG)
+			log_timestamp=${EPOCHREALTIME}
+			((use_logger)) && logger -t "cake-autorate.${instance_id}" "INFO: ${log_timestamp} ${msg}"
 			;;
 		*)
 			log_timestamp=${EPOCHREALTIME}


### PR DESCRIPTION
…to improve the log type tag

Placed at the current position before ${instance_id} is initiated the SYSLOG message looked like:

Jan 20 19:59:25 turris cake-autorate.: SYSLOG: 1674244765.530486 Starting cake-autorate with config: /root/cake-autorate/cake-autorate_config.vdsl2.sh

missing the ${instance_id} as suffix after autorate to disambiguate different instances with this commit this message now looks like expected:

Jan 20 20:01:53 turris cake-autorate.vdsl2: SYSLOG: 1674244913.515046 Starting cake-autorate with config: /root/cake-autorate/cake-autorate_config.vdsl2.sh

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>