### PR TITLE
Replace FIFOs with file descriptors and other improvements and fixes

### DIFF
--- a/cake-autorate-setup.sh
+++ b/cake-autorate-setup.sh
@@ -27,6 +27,9 @@ cd cake-autorate/ || exit
 # rm the main script and fetch a fresh copy
 [[ -f cake-autorate.sh ]] && rm cake-autorate.sh
 wget -q "$SRC_DIR"cake-autorate.sh
+[[ -f lib.sh ]] && rm lib.sh
+wget -q "$SRC_DIR"lib.sh
+chmod +x lib.sh
 
 # Check if a configuration file exists, and ask whether to keep it
 

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -17,6 +17,7 @@
 # Possible performance improvement
 export LC_ALL=C
 
+source /root/cake-autorate/lib.sh
 trap cleanup_and_killall INT TERM EXIT
 
 cleanup_and_killall()
@@ -1128,57 +1129,6 @@ verify_ifs_up()
 		[[ ! -f ${rx_bytes_path} ]] && log_msg "DEBUG" "Warning: The configured download interface: '${dl_if}' does not appear to be present. Waiting ${if_up_check_interval_s} seconds for the interface to come up." 
 		[[ ! -f ${tx_bytes_path} ]] && log_msg "DEBUG" "Warning: The configured upload interface: '${ul_if}' does not appear to be present. Waiting ${if_up_check_interval_s} seconds for the interface to come up." 
 		sleep_s ${if_up_check_interval_s}
-	done
-}
-
-sleep_s()
-{
-	# calling external sleep binary is slow
-	# bash does have a loadable sleep
-	# but read's timeout can more portably be exploited and this is apparently even faster anyway
-
-	local sleep_duration_s=${1} # (seconds, e.g. 0.5, 1 or 1.5)
-
-	read -t ${sleep_duration_s} <><(:) || :
-}
-
-sleep_us()
-{
-	local sleep_duration_us=${1} # (microseconds)
-
-	sleep_duration_s=000000${sleep_duration_us}
-	sleep_duration_s=$((10#${sleep_duration_s::-6})).${sleep_duration_s: -6}
-	sleep_s ${sleep_duration_s}
-}
-
-sleep_remaining_tick_time()
-{
-	# sleeps until the end of the tick duration
-
-	local t_start_us=${1} # (microseconds)
-	local tick_duration_us=${2} # (microseconds)
-
-	sleep_duration_us=$(( ${t_start_us} + ${tick_duration_us} - ${EPOCHREALTIME/./} ))
-	
-	if (( ${sleep_duration_us} > 0 )); then
-		sleep_us ${sleep_duration_us}
-	fi
-}
-
-randomize_array()
-{
-	local -n array=${1}
-
-	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
-
-	subset=(${array[@]})
-	array=()
-	for ((set=${#subset[@]}; set>0; set--))
-	do
-		idx=$((RANDOM%set))
-		array+=("${subset[idx]}")
-		unset subset[idx]
-		subset=(${subset[@]})
 	done
 }
 

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -622,7 +622,7 @@ start_pinger()
 			pinger=0
 			mkfifo ${run_path}/pinger_${pinger}_fifo
 			exec {pinger_fds[pinger]}<> ${run_path}/pinger_${pinger}_fifo
-			${ping_prefix_string} fping ${ping_extra_args} --timestamp --loop --period ${reflector_ping_interval_ms} --interval ${ping_response_interval_ms} --timeout 10000 ${reflectors[@]:0:${no_pingers}} 2> /dev/null > ${run_path}/pinger_${pinger}_fifo&
+			${ping_prefix_string} fping ${ping_extra_args} --timestamp --loop --period ${reflector_ping_interval_ms} --interval ${ping_response_interval_ms} --timeout 10000 "${reflectors[@]:0:${no_pingers}}" 2> /dev/null > ${run_path}/pinger_${pinger}_fifo&
 		;;
 		ping)
 			mkfifo ${run_path}/pinger_${pinger}_fifo
@@ -1433,8 +1433,8 @@ t_dl_last_decay_us=${t_start_us}
 
 t_sustained_connection_idle_us=0
 
-declare -a dl_delays=( $(for i in {1..${bufferbloat_detection_window}}; do echo 0; done) )
-declare -a ul_delays=( $(for i in {1..${bufferbloat_detection_window}}; do echo 0; done) )
+mapfile -t dl_delays < <(for ((i=1; i <= bufferbloat_detection_window; i++)); do echo 0; done)
+mapfile -t ul_delays < <(for ((i=1; i <= bufferbloat_detection_window; i++)); do echo 0; done)
 
 delays_idx=0
 sum_dl_delays=0

--- a/cake-autorate_launcher.sh
+++ b/cake-autorate_launcher.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+source /root/cake-autorate/lib.sh
 cake_instances=(/root/cake-autorate/cake-autorate_config*sh)
 
 trap kill_cake_instances INT TERM EXIT
@@ -25,6 +26,6 @@ do
 	cake_instance_list+=(${cake_instance})
 done
 
-sleep inf&
+sleep_inf&
 sleep_pid+=($!)
 wait

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,71 @@
+# lib.sh -- common functions for use by cake-autorate.sh
+# This file is part of cake-autorate.
+
+__set_e=0
+if [[ ! ${-} =~ e ]]; then
+    set -e
+    __set_e=1
+fi
+
+exec {__sleep_fd}<> <(:)
+
+sleep_inf()
+{
+	# sleeps forever
+	read -u ${__sleep_fd} || :
+}
+
+sleep_s()
+{
+	# calling external sleep binary is slow
+	# bash does have a loadable sleep
+	# but read's timeout can more portably be exploited and this is apparently even faster anyway
+
+	local sleep_duration_s=${1} # (seconds, e.g. 0.5, 1 or 1.5)
+
+	read -t ${sleep_duration_s} -u ${__sleep_fd} || :
+}
+
+sleep_us()
+{
+	local sleep_duration_us=${1} # (microseconds)
+
+	sleep_duration_s=000000${sleep_duration_us}
+	sleep_duration_s=$((10#${sleep_duration_s::-6})).${sleep_duration_s: -6}
+
+	sleep_s ${sleep_duration_s}
+}
+
+sleep_remaining_tick_time()
+{
+	# sleeps until the end of the tick duration
+
+	local t_start_us=${1} # (microseconds)
+	local tick_duration_us=${2} # (microseconds)
+
+	sleep_duration_us=$(( ${t_start_us} + ${tick_duration_us} - ${EPOCHREALTIME/./} ))
+	
+	if (( ${sleep_duration_us} > 0 )); then
+		sleep_us ${sleep_duration_us}
+	fi
+}
+
+randomize_array()
+{
+	local -n array=${1}
+
+	subset=(${array[@]})
+	array=()
+	for ((set=${#subset[@]}; set>0; set--))
+	do
+		idx=$((RANDOM%set))
+		array+=("${subset[idx]}")
+		unset subset[idx]
+		subset=(${subset[@]})
+	done
+}
+
+if (( ${__set_e} == 1 )); then
+    set +e
+fi
+unset __set_e


### PR DESCRIPTION
* `${reflectors[@]:0:${no_pingers}}` without quotes has the risk of
  being expanded improperly if an array element contains spaces
  (never going to happen but it doesn't hurt to put it in quotes)

* dl_delays and ul_delays are initialized improperly, at startup
  they only have one element because `for i in {1..${bufferbloat_detection_window}};`
  doesn't get expanded into `for i in {1..<some num here>}`..
  (limitation of brace expressions)