### PR TITLE
Plot pure load data fix

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,33 @@
+Challenge change cake-autorate more to my taste ;)
+
+
+use flock to serialize pinger kill/start sequences from each other
+
+use `kill -0 $PID` to test whether a kill was successful instead of wait
+
+use a second attempt with `kill -9` if the first kill did not succed.
+
+
+Try to restructure things:
+
+0) think hard about what should and what should not run concurrently
+    0.A) try restraint with trap
+
+
+1) use one process pair per reflector (no multiplexed pingers) implement only gnu ping, busybox ping and tsping (and ntp)
+    1.a) make pingers only runn for X iterations then restart them with a given time offset
+
+2) try to structure the main loop as state machine with sane transitions and helper functions for state
+
+3) trigger the mainloop both by ping and load messages from a single FIFO?
+    3.a) can the result of a read in a variable be parsed again?
+	use a parser that detects the "message" type (DELAY, TRAFFIC, CPULOAD, COMMAND, ...)
+	
+4) also track per CPU load (probably simply as 100-%idle)
+
+5) required states:
+    POLLING, SLEEP, STALL, ...
+    
+6) move all individual processes to their own files, so that top/htop/ps give meaningful indication what a process does
+
+7) implement command FIFOs back from the main loop to the background processes? Or

--- a/fn_parse_autorate_log.m
+++ b/fn_parse_autorate_log.m
@@ -232,7 +232,7 @@ function [ ] = fn_parse_autorate_log( log_FQN, plot_FQN, x_range_sec, selected_r
 %			end
 
 			% these can be replaced...
-			if isfield(autorate_log.DATA.LISTS, 'DL_ACHIEVED_RATE_KBPS')
+			if isfield(autorate_log.LOAD.LISTS, 'DL_ACHIEVED_RATE_KBPS')
 				rates.LOAD.fields_to_plot_list{end+1} = 'DL_ACHIEVED_RATE_KBPS';
 				rates.LOAD.color_list{end+1} = [208,28,139]/254;
 				rates.LOAD.linestyle_list{end+1} = '-';
@@ -243,7 +243,7 @@ function [ ] = fn_parse_autorate_log( log_FQN, plot_FQN, x_range_sec, selected_r
 				rates.DATA.linestyle_list(rate_DATA_idx) = [];
 				rates.DATA.sign_list(rate_DATA_idx) = [];
 			end
-			if isfield(autorate_log.DATA.LISTS, 'UL_ACHIEVED_RATE_KBPS')
+            if isfield(autorate_log.LOAD.LISTS, 'UL_ACHIEVED_RATE_KBPS')
 				rates.LOAD.fields_to_plot_list{end+1} = 'UL_ACHIEVED_RATE_KBPS';
 				rates.LOAD.color_list{end+1} = [77,172,38]/254;
 				rates.LOAD.linestyle_list{end+1} = '-';
@@ -648,16 +648,18 @@ function [ ] = fn_parse_autorate_log( log_FQN, plot_FQN, x_range_sec, selected_r
 				endfor
 			endif
 
-			try
-				if strcmp(graphics_toolkit, 'gnuplot')
-					legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
-				else
-					legend(legend_list, 'Interpreter', 'none', 'numcolumns', 2, 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
-				end
-			catch
-				disp(['Triggered']);
-				legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'FontSize', 7);
-			end_try_catch
+			if ~isempty(legend_list)
+				try
+					if strcmp(graphics_toolkit, 'gnuplot')
+						legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
+					else
+						legend(legend_list, 'Interpreter', 'none', 'numcolumns', 2, 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
+					end
+				catch
+					disp(['Triggered']);
+					legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'FontSize', 7);
+				end_try_catch
+			end
 			hold off
 			xlabel(x_label_string);
 			ylabel('Rate [Mbps]');
@@ -676,15 +678,17 @@ function [ ] = fn_parse_autorate_log( log_FQN, plot_FQN, x_range_sec, selected_r
 				if ~isempty(adjusted_ylim_delay)
 					set(cur_sph, 'YLim', (adjusted_ylim_delay * delays.DATA.scale_factor));
 				endif
-				try
-					if strcmp(graphics_toolkit, 'gnuplot')
-						legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
-					else
-						legend(legend_list, 'Interpreter', 'none', 'numcolumns', 3, 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
-					end
-				catch
-					legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'FontSize', 7);
-				end_try_catch
+				if ~isempty(legend_list)
+					try
+						if strcmp(graphics_toolkit, 'gnuplot')
+							legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
+						else
+							legend(legend_list, 'Interpreter', 'none', 'numcolumns', 3, 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
+						end
+					catch
+						legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'FontSize', 7);
+					end_try_catch
+				end
 				hold off
 				xlabel(x_label_string);
 				ylabel('Delay [milliseconds]');


### PR DESCRIPTION
Fixes a regression in te plotting scripts handling of LOAD records in the absence of DATA record entries.
Should fix:
https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/2276