### PR TITLE
docs: Factor README

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,13 +1,10 @@
 # Analyzing CAKE-autorate data
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
-bandwidth settings based on traffic load and round-trip time measurements.
-See the main [README](./README.md) page for more details of the algorithm.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. See the main [README](./README.md) page for more details of the algorithm.
 
 ## Exporting a Log File
 
-Extract a compressed log file from a running
-cake-autorate instance using one of these methods:
+Extract a compressed log file from a running cake-autorate instance using one of these methods:
 
 1. Run the auto-generated _log\_file\_export_ script inside the run directory:
 
@@ -23,13 +20,11 @@ cake-autorate instance using one of these methods:
    kill -USR1 $(cat /var/run/cake-autorate/*/proc_state | grep -E    '^maintain_log_file=' | cut -d= -f2)
    ```
 
-Either will place a compressed log file in _/var/log_
-with the date and time in its filename.
+Either will place a compressed log file in _/var/log_ with the date and time in its filename.
 
 ## Rotating the Log File
 
-Force a log file rotation on a running
-cake-autorate instance by using one of these methods:
+Force a log file rotation on a running cake-autorate instance by using one of these methods:
 
 1. Run the auto-generated log_file_rotate script inside the run directory:
 
@@ -47,29 +42,19 @@ cake-autorate instance by using one of these methods:
 
 ## Plotting the Log File
 
-The excellent Octave/Matlab program _fn\_parse\_autorate\_log.m_
-by @moeller0 of OpenWrt can read an exported log file and
-produce a helpful graph like this:
+The excellent Octave/Matlab program _fn\_parse\_autorate\_log.m_ by @moeller0 of OpenWrt can read an exported log file and produce a helpful graph like this:
 
 <img src="https://user-images.githubusercontent.com/10721999/194724668-d8973bb6-5a37-4b05-a212-3514db8f56f1.png" width=80% height=80%>
 
-The command below will run the Octave program (see the introductory notes in
-_fn\_parse\_autorate\_log.m_ for more details):
+The command below will run the Octave program (see the introductory notes in _fn\_parse\_autorate\_log.m_ for more details):
 
 ```bash
 octave -qf --eval 'fn_parse_autorate_log("./log.gz", "./output.pdf")'
 ```
 
-The script below runs on a laptop to extract the log from the router
-and generate the pdfs for viewing from a client machine:
+The script below can be run on a remote machine to extract the log from the router and generate the pdfs for viewing from the remote machine:
 
 ```bash
 log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"
 octave -qf --eval 'fn_parse_autorate_log("./*primary*log.gz", "./output.pdf")'
 ```
-  
-## A Request to Testers
-
-If you use this script, please post your experience on this
-[OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/).
-Your feedback will help improve the script for the benefit of others.  

--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,11 +1,13 @@
 # Analyzing CAKE-autorate data
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
+bandwidth settings based on traffic load and round-trip time measurements.
 See the main [README](./README.md) page for more details of the algorithm.
 
 ## Exporting a Log File ##
 
-A compressed log file can be extracted from a running cake-autorate instance using one of either two methods:
+A compressed log file can be extracted from a running
+cake-autorate instance using one of either two methods:
 
 1. Run the auto-generated _log\_file\_export_ script inside the run directory:
 
@@ -15,23 +17,26 @@ A compressed log file can be extracted from a running cake-autorate instance usi
 
    ... or ...
 
-2.	Send a USR1 signal to the main log file process using:
+2. Send a USR1 signal to the main log file process using:
 
    ```bash
    kill -USR1 $(cat /var/run/cake-autorate/*/proc_state | grep -E    '^maintain_log_file=' | cut -d= -f2)
    ```
 
-Either will place a compressed log file in _/var/log_ with the date and time in its filename.
+Either will place a compressed log file in _/var/log_
+with the date and time in its filename.
 
-## Rotating the Log File 
+## Rotating the Log File
 
-Similarly, a log file rotation can be requested on a running cake-autorate instance by using one of either two methods
+Similarly, a log file rotation can be requested on a running
+cake-autorate instance by using one of either two methods
 
 1. Run the auto-generated log_file_rotate script inside the run directory:
 
-	```bash
+   ```bash
    /var/run/cake-autorate/*/log_file_rotate
    ```
+
    ... or ...
 
 2. Send a USR2 signal to the main log file process using:
@@ -40,19 +45,23 @@ Similarly, a log file rotation can be requested on a running cake-autorate insta
    kill -USR2 $(cat /var/run/cake-autorate/*/proc_state | grep -E '^maintain_log_file=' | cut -d= -f2)
    ```
 
-## Plotting the Log File 
+## Plotting the Log File
 
-The excellent Octave/Matlab program _fn\_parse\_autorate\_log.m_ by @moeller0 of OpenWrt can read an exported log file and produce a helpful graph like this:
+The excellent Octave/Matlab program _fn\_parse\_autorate\_log.m_
+by @moeller0 of OpenWrt can read an exported log file and
+produce a helpful graph like this:
 
 <img src="https://user-images.githubusercontent.com/10721999/194724668-d8973bb6-5a37-4b05-a212-3514db8f56f1.png" width=80% height=80%>
 
-The command below will run the Octave program (see the introductory notes in _fn\_parse\_autorate\_log.m_ for more details):
- 
+The command below will run the Octave program (see the introductory notes in
+_fn\_parse\_autorate\_log.m_ for more details):
+
 ```bash
 octave -qf --eval 'fn_parse_autorate_log("./log.gz", "./output.pdf")'
 ```
 
-The script below runs on a laptop to extract the log from the router and generate the pdfs for viewing from a client machine:
+The script below runs on a laptop to extract the log from the router
+and generate the pdfs for viewing from a client machine:
 
 ```bash
 log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"
@@ -61,4 +70,6 @@ octave -qf --eval 'fn_parse_autorate_log("./*primary*log.gz", "./output.pdf")'
   
 ## A Request to Testers
 
-If you use this script, please post your experience on this [OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/). Your feedback will help improve the script for the benefit of others.  
+If you use this script, please post your experience on this
+[OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/).
+Your feedback will help improve the script for the benefit of others.  

--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -4,10 +4,10 @@
 bandwidth settings based on traffic load and round-trip time measurements.
 See the main [README](./README.md) page for more details of the algorithm.
 
-## Exporting a Log File ##
+## Exporting a Log File
 
-A compressed log file can be extracted from a running
-cake-autorate instance using one of either two methods:
+Extract a compressed log file from a running
+cake-autorate instance using one of these methods:
 
 1. Run the auto-generated _log\_file\_export_ script inside the run directory:
 
@@ -28,8 +28,8 @@ with the date and time in its filename.
 
 ## Rotating the Log File
 
-Similarly, a log file rotation can be requested on a running
-cake-autorate instance by using one of either two methods
+Force a log file rotation on a running
+cake-autorate instance by using one of these methods:
 
 1. Run the auto-generated log_file_rotate script inside the run directory:
 

--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,64 @@
+# Analyzing CAKE-autorate data
+
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements.
+See the main [README](./README.md) page for more details of the algorithm.
+
+## Exporting a Log File ##
+
+A compressed log file can be extracted from a running cake-autorate instance using one of either two methods:
+
+1. Run the auto-generated _log\_file\_export_ script inside the run directory:
+
+   ```bash
+   /var/run/cake-autorate/*/log_file_export
+   ```
+
+   ... or ...
+
+2.	Send a USR1 signal to the main log file process using:
+
+   ```bash
+   kill -USR1 $(cat /var/run/cake-autorate/*/proc_state | grep -E    '^maintain_log_file=' | cut -d= -f2)
+   ```
+
+Either will place a compressed log file in _/var/log_ with the date and time in its filename.
+
+## Rotating the Log File 
+
+Similarly, a log file rotation can be requested on a running cake-autorate instance by using one of either two methods
+
+1. Run the auto-generated log_file_rotate script inside the run directory:
+
+	```bash
+   /var/run/cake-autorate/*/log_file_rotate
+   ```
+   ... or ...
+
+2. Send a USR2 signal to the main log file process using:
+
+   ```bash
+   kill -USR2 $(cat /var/run/cake-autorate/*/proc_state | grep -E '^maintain_log_file=' | cut -d= -f2)
+   ```
+
+## Plotting the Log File 
+
+The excellent Octave/Matlab program _fn\_parse\_autorate\_log.m_ by @moeller0 of OpenWrt can read an exported log file and produce a helpful graph like this:
+
+<img src="https://user-images.githubusercontent.com/10721999/194724668-d8973bb6-5a37-4b05-a212-3514db8f56f1.png" width=80% height=80%>
+
+The command below will run the Octave program (see the introductory notes in _fn\_parse\_autorate\_log.m_ for more details):
+ 
+```bash
+octave -qf --eval 'fn_parse_autorate_log("./log.gz", "./output.pdf")'
+```
+
+The script below runs on a laptop to extract the log from the router and generate the pdfs for viewing from a client machine:
+
+```bash
+log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"
+octave -qf --eval 'fn_parse_autorate_log("./*primary*log.gz", "./output.pdf")'
+```
+  
+## A Request to Testers
+
+If you use this script, please post your experience on this [OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/). Your feedback will help improve the script for the benefit of others.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This 2.1 release improves the implementation over earlier versions.
 - Employ FIFOs for passing not only data, but also commands, between the major processes, obviating costly reliance on temporary files. A side effect of this is that now /var/run/cake-autorate is mostly empty during runs.
 - Significantly reduced CPU consumption.
 - Fixed eternal sleep issue.
-- Introduce more user-friendly config format by introducing cake-autorate_defaults.sh and cake-autorate_config.X.sh with the basics (interface names, whether to adjust the shaper rates and the min, base and max shaper rates) and any overrides from the default. 
+- Introduce more user-friendly config format by introducing cake-autorate_defaults.sh and cake-autorate_config.X.sh with the basics (interface names, whether to adjust the shaper rates and the min, base and max shaper rates) and any overrides from the default.
 - More intelligent check for another running instance.
 - Introduce more user-friendly log file exports by automatically generating an export script for each running cake-autorate instance inside /var/run/cake-autorate/*/.
 - Many more fixes and improvements.
@@ -29,22 +29,22 @@ This 2.1 release improves the implementation over earlier versions.
 
 ## 2022-12-13 - Version 1.2
 
-- cake-autorate now includes a sophisticated offline log file analysis utility written in Matlab/Octave: 'fn_parse_autorate_log.m' and maintained by @moeller0 (OpenWrt forum). This utility takes in a cake-autorate generated log file (in compressed or uncompressed format), which can be generated on the fly by sending an appropriate signal, and presents beautiful plots that depict latency and bandwidth over time together with many important cake-autorate vitals. This gratly simplifies assessing the efficacy of cake-autorate and associated settings on a given connection. 
-- Multiple instances of cake-autorate is now supported. cake-autorate can now be run on multiple interfaces such as in the case of mwan3 failover. The interface is assigned by designating an appropaite interface identifier 'X' in the config file in the form cake-autorate_config.X.sh. A launcher script has been created that creates one cake-autorate instance per cake-autorate_config file placed inside /root/cake-autorate/. Log files are generated for each instance using the form /var/log/cake-autorate.X.log. The interface identifier 'X' cannot be empty. 
-- Improved reflector management. With a relatively high frequency (default 1 minute) cake-autorate now compares reflector baselines and deltas and rotates out reflectors with either baselines that are excessively higher than the minimum or deltas that are too close to the trigger threshold. And with a relatively low frequency (default 60 minutes), cake-autorate now randomly rotates out a reflector from the presently active list. This simple algorithm is intended to converge upon a set of good reflectors from the intitial starting set. The initial starting set is now also randomized from the provided list of reflectors. The user is still encouraged to test the initial reflector list to rule out any particularly far away or highly variable reflectors. 
--  Reflector stats may now optionally be printed to help monitor the efficacy of the reflector management and quality of the present reflectors. 
--  LOAD stats may now optionally be printed to monitor achieved rates during sleep periods when pingers are shutdown.  
--  For each new sample, the baseline is now subtracted after having been updated rather than before having been updated. 
--  Pinger prefix and arguments are now facilitated for the chosen pinger binary to help improve compatibility with mwan3.
--  Consideration was afforded to switching over to the use of SMA rather than EWMA for reflector baselines, but SMA was found to offer minimal improvement as compared to EWMA with appropriately chosen alpha values. The present use of EWMA with multiple alphas for increase and decrease enables tracking of either reflector owd minimums (conservative default) or averages (by setting alphas to around e.g. 0.095). 
--  User can now specify own log path, e.g. in case of logging out to cloud mount using rclone or USB stick
+- cake-autorate now includes a sophisticated offline log file analysis utility written in Matlab/Octave: 'fn_parse_autorate_log.m' and maintained by @moeller0 (OpenWrt forum). This utility takes in a cake-autorate generated log file (in compressed or uncompressed format), which can be generated on the fly by sending an appropriate signal, and presents beautiful plots that depict latency and bandwidth over time together with many important cake-autorate vitals. This gratly simplifies assessing the efficacy of cake-autorate and associated settings on a given connection.
+- Multiple instances of cake-autorate is now supported. cake-autorate can now be run on multiple interfaces such as in the case of mwan3 failover. The interface is assigned by designating an appropaite interface identifier 'X' in the config file in the form cake-autorate_config.X.sh. A launcher script has been created that creates one cake-autorate instance per cake-autorate_config file placed inside /root/cake-autorate/. Log files are generated for each instance using the form /var/log/cake-autorate.X.log. The interface identifier 'X' cannot be empty.
+- Improved reflector management. With a relatively high frequency (default 1 minute) cake-autorate now compares reflector baselines and deltas and rotates out reflectors with either baselines that are excessively higher than the minimum or deltas that are too close to the trigger threshold. And with a relatively low frequency (default 60 minutes), cake-autorate now randomly rotates out a reflector from the presently active list. This simple algorithm is intended to converge upon a set of good reflectors from the intitial starting set. The initial starting set is now also randomized from the provided list of reflectors. The user is still encouraged to test the initial reflector list to rule out any particularly far away or highly variable reflectors.
+- Reflector stats may now optionally be printed to help monitor the efficacy of the reflector management and quality of the present reflectors.
+- LOAD stats may now optionally be printed to monitor achieved rates during sleep periods when pingers are shutdown.  
+- For each new sample, the baseline is now subtracted after having been updated rather than before having been updated.
+- Pinger prefix and arguments are now facilitated for the chosen pinger binary to help improve compatibility with mwan3.
+- Consideration was afforded to switching over to the use of SMA rather than EWMA for reflector baselines, but SMA was found to offer minimal improvement as compared to EWMA with appropriately chosen alpha values. The present use of EWMA with multiple alphas for increase and decrease enables tracking of either reflector owd minimums (conservative default) or averages (by setting alphas to around e.g. 0.095).
+- User can now specify own log path, e.g. in case of logging out to cloud mount using rclone or USB stick
 
 ## 2022-09-28 - Version 1.1
 
 Implemented several new features such as:
 
 - Switch default pinger binary to fping - it was identified that using concurrent instances of iputils-ping resulted in drift between ICMP requests, and fping solves this because it offers round robin pinging to multiple reflectors with tightly controlled timing between requests
-- Generalised pinger functions to support wrappers for different ping binaries - fping and iputils-ping now specifically supported and handled, and new ping binaries can easily be added by including appropriate wrapper functions. 
+- Generalised pinger functions to support wrappers for different ping binaries - fping and iputils-ping now specifically supported and handled, and new ping binaries can easily be added by including appropriate wrapper functions.
 - Generalised code to work with one way delays (OWDs) from RTTs in preparation to use ICMP type 13 requests
 - Only use capacity estimate on bufferbloat detection where the adjusted shaper rate based thereon would exceed the minimum configured shaper rate (avoiding the situation where e.g. idle load on download during upload-related bufferbloat would cause download shaper rate to get punished all the way down to the minimum)
 - Stall detection and handling
@@ -52,15 +52,15 @@ Implemented several new features such as:
 
 ## 2022-08-21 - Version 1.0
 
-- New installer script - cake-autorate-setup.sh - now installs all required files 
-- Installer checks for presence of previous config and asks whether to overwrite 
+- New installer script - cake-autorate-setup.sh - now installs all required files
+- Installer checks for presence of previous config and asks whether to overwrite
 - Installer also copies the service script into `/etc/init.d/cake-autorate`
-- Installer does NOT start the software, but displays instructions for config and starting 
+- Installer does NOT start the software, but displays instructions for config and starting
 - At startup, display version number and interface name and configured speeds
 - Abort if the configured interfaces do not exist
 - Style guide: the name of the algorithm and repo is "CAKE-autorate"
 - All "cake-autorate..." filenames are lower case
-- New log_msg() function that places a simple time stamp on the each line 
+- New log_msg() function that places a simple time stamp on the each line
 - Moved images to their own directory
 - No other new/interesting functionality
 
@@ -87,7 +87,7 @@ Implemented several new features such as:
 
 ## 2022-04-19
 
-- Many further optimizations to reduce CPU use and improve performance 
+- Many further optimizations to reduce CPU use and improve performance
 - Replaced coreutils-sleep with 'read -t' on dummy fifo to use bash inbuilt
 - Added various features to help with weaker LTE connections
 - Implemented significant number of robustifications
@@ -95,7 +95,7 @@ Implemented several new features such as:
 ## 2022-03-21
 
 - Huge reworking of CAKE-autorate. Now individual processes ping a reflector, maintain a baseline, and write out result lines to a common FIFO that is read in by a main loop and processed. Several optimisations have been effected to reduce CPU load. Sleep functionality has been added to put the pinging processes to sleep when the connection is not being used and to wake back up when the connection is used again - this saves unecessary CPU cycles and issuing pings throughout the 'wee' hours of the night.
-- This script seems to be working very well on the author's LTE conneciton. The author personally uses it as a service 24/7 now. 
+- This script seems to be working very well on the author's LTE conneciton. The author personally uses it as a service 24/7 now.
 
 ## 2022-02-18
 
@@ -105,7 +105,7 @@ Implemented several new features such as:
 ## 2022-02-17
 
 - Completed and uploaded to new CAKE-autorate branch completely new bash implementation
-- This will likely be the future for this project 
+- This will likely be the future for this project
 
 ## 2022-02-04
 
@@ -128,19 +128,19 @@ Implemented several new features such as:
 
 ## 2021-12-9
 
-- Based on discussion in OpenWrt CAKE /w Adaptive Bandwidth thread created new 'owd' branch 
+- Based on discussion in OpenWrt CAKE /w Adaptive Bandwidth thread created new 'owd' branch
 - Adapted code to employ timestamp ICMP type 13 requests to try to ascertain direction of bufferbloat
 - On OpenWrt CAKE /w Adaptive Bandwidth thread much testing/discussion around various ping utilities
 - nping found to support ICMP type 13 but slow and unreliable
 - settled on hping3 as identified by @Locknair (OpenWrt forum) as ery efficient and timing information proves reliable
-- @Failsafe (OpenWrt forum) demonstrated awk mastery by writing awk parser to handle output of hping3 
+- @Failsafe (OpenWrt forum) demonstrated awk mastery by writing awk parser to handle output of hping3
 
 ## 2021-12-6
 
 - Reverted to old behaviour of decrementing both downlink and uplink rates upon bufferbloat detection
 - Whilst guestimating direction of bufferbloat based on load is a nice idea/hack, it proved dangerous and unreliable
 - Namely, suppose downlink load is 0.8 and uplink load is 0.4 and it is uplink that causes bufferbloat
-- In this situation, decrementing downlink rate (because this is the heavily loaded direction) does not solve 
+- In this situation, decrementing downlink rate (because this is the heavily loaded direction) does not solve
 - The bufferbloat, and this could result in downlink bandwidth being punished down to zero
 
 ## 2021-12-4
@@ -168,13 +168,13 @@ Implemented several new features such as:
 
 ## 2021-10-19
 
-- sqm-autorate is born! 
+- sqm-autorate is born!
 - A brief history:
 - @Lynx (OpenWrt forum) wondered about simple algorith along the lines:
 - if load < 50% of minimum set load then assume no load and update moving average of unloaded ping to 8.8.8.8
 if load > 50% of minimum set load acquire set of sample points by pinging 8.8.8.8 and acquire sample mean
 measure bufferbloat by subtracting moving average of unloaded ping from sample mean
 ascertain load during sample acquisition and make bandwidth increase or decrease decision based on determined load and determination of bufferbloat or not
-- And @Lynx asked SQM/CAKE expert @moeller0 (OpenWrt forum) to suggest a basic algorithm. 
-- @moeller0 suggested the following approach: https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/88?u=lynx
+- And @Lynx asked SQM/CAKE expert @moeller0 (OpenWrt forum) to suggest a basic algorithm.
+- @moeller0 suggested the following approach: <https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/88?u=lynx>
 - @Lynx wrote a shell script to implement this routine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 # Changelog
 
-**autorate.sh** is a script that automatically adapts
-[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/)
-bandwidth settings by measuring traffic load and RTT times.
-Read the [README](./README.md) file for more details.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements.
+Read the [README](./README.md) file for more about CAKE-autorate.
 This is the history of changes.
+
+## 2023-06-?? - Version 2.1
+
+The theory of operation of CAKE-autorate remains the same.
+This 2.1 release improves the implementation over earlier versions.
+
+- CAKE-autorate has even lower CPU requirements and can now run successfully on older routers.
+- Many changes to catch and handle unusual error conditions
+- Log files: Improved rotation, and better information for analysis
+- Incorporate the ability to use different ping binary programs
 
 ## 2023-04-13 - Version 2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,13 @@
 # Changelog
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements.
-Read the [README](./README.md) file for more about CAKE-autorate.
-This is the history of changes.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and one-way-delay or round-trip time measurements.
+Read the [README](./README.md) file for more about CAKE-autorate. This is the history of changes.
 
-## 2023-06-?? - Version 2.1
-
-The theory of operation of CAKE-autorate remains the same.
-This 2.1 release improves the implementation over earlier versions.
-
-- CAKE-autorate has even lower CPU requirements and can now run successfully on older routers.
-- Many changes to catch and handle unusual error conditions
-- Log files: Improved rotation, and better information for analysis
-- Incorporate the ability to use different ping binary programs
-
-## 2023-04-13 - Version 2.0
+## 2023-05-27 - Version 2.0
 
 - This version incorporates a restructure of the bash code for improved robustness, stability and performance.
+- CAKE-autorate has even lower CPU requirements and can now run successfully on older routers.
+- Many changes to catch and handle unusual error conditions
 - Introduce support for one way delays (OWDs) using the 'tsping' binary developed by @Lochnair of the OpenWrt forum. This works with ICMP type 13 (timestamp) requests to ascertain the delay in each direction (i.e. OWDs).
 - Employ FIFOs for passing not only data, but also commands, between the major processes, obviating costly reliance on temporary files. A side effect of this is that now /var/run/cake-autorate is mostly empty during runs.
 - Significantly reduced CPU consumption.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,23 +1,17 @@
 # Installing CAKE-autorate on OpenWrt
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
-bandwidth settings based on traffic load and round-trip time measurements.
-See the main [README](./README.md) page for more details of the algorithm.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. See the main [README](./README.md) page for more details of the algorithm.
 
 ## Installation Steps
 
-CAKE-autorate provides an installation script that installs all the required tools.
-To use it:
+CAKE-autorate provides an installation script that installs all the required tools. To use it:
 
-- Install SQM (`luci-app-sqm`) and enable and configure `cake`
-Queue Discipline on the interface(s) as described in the
-[OpenWrt SQM documentation](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
-You may have more complex networking needs:
-DSCPs - consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple);
-WireGuard with PBR - consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
+- Install SQM (`luci-app-sqm`) and enable and configure `cake` Queue Discipline on the interface(s) as described in the [OpenWrt SQM documentation](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
+- Alternatively, and especially if you may have more complex networking needs:
+   - DSCPs - consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple);
+   - WireGuard with PBR - consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
-- Use the installer script by copying and
-pasting each of the commands below.
+- Use the installer script by copying and pasting each of the commands below.
 The commands retrieve the current version from this repo:
 
    ```bash
@@ -26,16 +20,11 @@ The commands retrieve the current version from this repo:
    sh /tmp/cake-autorate_setup.sh
    ```
 
-- The installer script will detect a previous configuration file,
-and ask whether to preserve it. If you do not keep it, you will need to...
-- Edit the _cake-autorate\_config.primary.sh_ script (in the
-_/root/cake-autorate_ directory) using vi or nano to set the
-configuration parameters below (see comments
-in _cake-autorate\_config.primary.sh_ for details).
+- The installer script will detect a previous configuration file, and ask whether to preserve it. 
+- For a fresh install, you will need to undertake the following steps.
+- Edit the _cake-autorate\_config.primary.sh_ script (in the _/root/cake-autorate_ directory) using vi or nano to set the configuration parameters below (see comments in _cake-autorate\_config.primary.sh_ for details).
 
-  - Change `dl_if` and `ul_if` to match the names of the upload and download
-  interfaces to which CAKE is applied.
-  These can be obtained, for example, by consulting the
+  - Change `dl_if` and `ul_if` to match the names of the upload and download interfaces to which CAKE is applied. These can be obtained, for example, by consulting the
   configured SQM settings in LuCI or by examining the output of `tc qdisc ls`.
 
       | Variable | Setting |
@@ -51,21 +40,16 @@ in _cake-autorate\_config.primary.sh_ for details).
       | Base | `base_dl_shaper_rate_kbps` | `base_ul_shaper_rate_kbps` |
       | Max. | `max_dl_shaper_rate_kbps` | `max_ul_shaper_rate_kbps` |
 
-    - Choose whether cake-autorate should adjust the shaper rates
-    (disable for monitoring only):
+   - Choose whether cake-autorate should adjust the shaper rates (disable for monitoring only):
   
       | Variable | Setting |
       |----: |   :-------- |
       | `adjust_dl_shaper_rate` | enable (1) or disable (0) download shaping |
       | `adjust_ul_shaper_rate` | enable (1) or disable (0) upload shaping |
 
-- The other configuration file - _cake-autorate\_defaults.sh_ -
-  has good default settings.
-  After CAKE-autorate has been installed and is
-  running, you may wish to change some of these.
+- The other configuration file - _cake-autorate\_defaults.sh_ - has sensible default settings. After CAKE-autorate has been installed and is running, you may wish to change some of these.
   
-  - For example, to set a different `dl_delay_thr_ms`, then
-  add a line to the config like:
+  - For example, to set a different `dl_delay_thr_ms`, then add a line to the config like:
   
      ```bash
      dl_delay_thr_ms=100
@@ -84,23 +68,19 @@ in _cake-autorate\_config.primary.sh_ for details).
 
 ## Manual testing
 
-To start the `cake-autorate.sh` script and watch the logged output
-as it adjusts the CAKE parameters, run these commands:
+To start the `cake-autorate.sh` script and watch the logged output as it adjusts the CAKE parameters, run these commands:
 
    ```bash
    cd /root/cake-autorate     # to the cake-autorate directory
    ./cake-autorate.sh
    ```
 
-- Monitor the script output to see how it adjusts the
-download and upload rates as you use the connection.
+- Monitor the script output to see how it adjusts the download and upload rates as you use the connection.
 - Press ^C to halt the process.
 
 ## Install as a service
 
-You can install CAKE-autorate as a service that starts up
-the autorate process whenever the router reboots.
-To do this:
+You can install CAKE-autorate as a service that starts up the autorate process whenever the router reboots. To do this:
 
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
 - Run these commands to enable and start the service file:
@@ -111,25 +91,18 @@ To do this:
    service cake-autorate start
    ```
 
-If you edit any of the configuration files,
-you will need to restart the service with `service cake-autorate restart`
+If you edit any of the configuration files, you will need to restart the service with `service cake-autorate restart`
 
-When running as a service, the `cake-autorate.sh` script outputs to
-_/var/log/cake-autorate.primary.log_ (observing the instance identifier
-_cake-autorate\_config.identifier.sh_ set in the config file name).
+When running as a service, the `cake-autorate.sh` script outputs to _/var/log/cake-autorate.primary.log_ (observing the instance identifier _cake-autorate\_config.identifier.sh_ set in the config file name).
 
-WARNING: Take care to ensure sufficient free (Flash) memory
-exists in router to handle selected logging parameters.
+WARNING: Take care to ensure sufficient free (Flash) memory exists in router to handle selected logging parameters.
 
 ## Preserving CAKE-autorate files for backup or upgrades
 
-OpenWrt devices can save files across upgrades. Read the
-[Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
+OpenWrt devices can save files across upgrades. Read the [Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
 for details.
 
-To ensure the CAKE-autorate script and configuration files are
-preserved, enter the files below to the OpenWrt router's
-[Configuration tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up)
+To ensure the CAKE-autorate script and configuration files are preserved, enter the files below to the OpenWrt router's [Configuration tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up)
 
  ```bash
 /root/cake-autorate
@@ -139,8 +112,7 @@ preserved, enter the files below to the OpenWrt router's
 ## Multi-WAN Setups
 
 - CAKE-autorate has been designed to run multiple instances simultaneously.
-- cake-autorate will run one instance per config file present
-in the _/root/cake-autorate/_ directory in the form:
+- cake-autorate will run one instance per config file present in the _/root/cake-autorate/_ directory in the form:
 
 ```bash
 cake-autorate_config.interface.sh
@@ -150,38 +122,19 @@ where 'interface' is replaced with e.g. 'primary', 'secondary', etc.
 
 ## Example Starlink Configuration
 
-- OpenWrt forum member @gba has kindly shared
-[his Starlink config](Example_Starlink_config.sh).
-This ought to provide some helpful pointers for adding
-appropriate overrides for Starlink users.
+- OpenWrt forum member @gba has kindly shared [his Starlink config](Example_Starlink_config.sh).
+This ought to provide some helpful pointers for adding appropriate overrides for Starlink users.
 - See discussion on OpenWrt thread from
 [around this post](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/3100?u=lynx).
 
 ## Selecting a "ping binary"
 
-CAKE-autorate reads the `$pinger_binary` variable in the
-config file to select the ping binary. Choices include:
+CAKE-autorate reads the `$pinger_binary` variable in the config file to select the ping binary. Choices include:
 
-- **fping** (DEFAULT) round robin pinging to multiple
-reflectors with tightly controlled timings
-- **tsping** round robin ICMP type 13 pinging to multiple
-reflectors with tightly controlled timings
-- **iputils-ping** more advanced pinging than the default
-busybox ping with sub 1s ping frequency
+- **fping** (DEFAULT) round robin pinging to multiple reflectors with tightly controlled timings
+- **tsping** round robin ICMP type 13 pinging to multiple reflectors with tightly controlled timings
+- **iputils-ping** more advanced pinging than the default busybox ping with sub 1s ping frequency
 
-**About tsping** @Lochnair has coded up an elegant ping utility in C
-that sends out ICMP type 13 requests in a round robin manner,
-thereby facilitating determination of one way delays (OWDs),
-i.e. not just round trip time (RTT), but the constituent
-download and upload delays, relative to multiple reflectors.
-Presently this must be compiled manually (although we can expect
-an official OpenWrt package soon).
+**About tsping** @Lochnair has coded up an elegant ping utility in C that sends out ICMP type 13 requests in a round robin manner, thereby facilitating determination of one way delays (OWDs), i.e. not just round trip time (RTT), but the constituent download and upload delays, relative to multiple reflectors. Presently this must be compiled manually (although we can expect an official OpenWrt package soon).
 
-Instructions for building a `tsping` OpenWrt package are available
-[from github.](https://github.com/Lochnair/tsping)
-
-## A Request to Testers
-
-If you use this script, please post your experience on this
-[OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/).
-Your feedback will help improve the script for the benefit of others.  
+Instructions for building a `tsping` OpenWrt package are available [from github.](https://github.com/Lochnair/tsping)

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -16,8 +16,9 @@ You may have more complex networking needs:
 DSCPs - consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple);
 WireGuard with PBR - consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
-- Use the installer script from this repo by copying and
-pasting each of the commands below:
+- Use the installer script by copying and
+pasting each of the commands below.
+The commands retrieve the current version from this repo:
 
    ```bash
    wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/CAKE-autorate/master/cake-autorate_setup.sh
@@ -26,20 +27,20 @@ pasting each of the commands below:
    ```
 
 - The installer script will detect a previous configuration file,
-and ask whether to preserve it. If you do not keep it...
+and ask whether to preserve it. If you do not keep it, you will need to...
 - Edit the _cake-autorate\_config.primary.sh_ script (in the
 _/root/cake-autorate_ directory) using vi or nano to set the
 configuration parameters below (see comments
-inside _cake-autorate-config.sh_ for details).
+in _cake-autorate\_config.primary.sh_ for details).
 
   - Change `dl_if` and `ul_if` to match the names of the upload and download
   interfaces to which CAKE is applied.
   These can be obtained, for example, by consulting the
-  configured SQM settings in LuCi or by examining the output of `tc qdisc ls`.
+  configured SQM settings in LuCI or by examining the output of `tc qdisc ls`.
 
       | Variable | Setting |
       |----: |   :-------- |
-      | `dl_if` | Interface that downloads data (often _ifb4-wan_ - check `tc qdisc ls`) |
+      | `dl_if` | Interface that downloads data (often _ifb4-wan_)
       | `ul_if` | Interface that uploads (often _wan_) |
 
   - Set bandwidth variables as described in _cake-autorate\_config.primary.sh_.
@@ -55,17 +56,20 @@ inside _cake-autorate-config.sh_ for details).
   
       | Variable | Setting |
       |----: |   :-------- |
-      | `adjust_dl_shaper_rate` | enable (1) or disable (0) actually changing the dl\_shaper\_rate |
-      | `adjust_ul_shaper_rate` | enable (1) or disable (0) actually changing the dl\_shaper\_rate |
+      | `adjust_dl_shaper_rate` | enable (1) or disable (0) download shaping |
+      | `adjust_ul_shaper_rate` | enable (1) or disable (0) upload shaping |
 
-  - Set any further overrides by inspecting _cake-autorate\_defaults.sh_
-  and setting different values for any of the defaults.
-  For example, to set a different `dl_delay_thr_ms`, then
+- The other configuration file - _cake-autorate\_defaults.sh_ -
+  has good default settings.
+  After CAKE-autorate has been installed and is
+  running, you may wish to change some of these.
+  
+  - For example, to set a different `dl_delay_thr_ms`, then
   add a line to the config like:
   
-  ```bash
-  dl_delay_thr_ms=100
-  ```
+     ```bash
+     dl_delay_thr_ms=100
+     ```
   
   - The following variables control logging:
 
@@ -80,8 +84,8 @@ inside _cake-autorate-config.sh_ for details).
 
 ## Manual testing
 
-To start the `cake-autorate.sh` script and watch the as it
-adjusts the CAKE parameters, run these commands:
+To start the `cake-autorate.sh` script and watch the logged output
+as it adjusts the CAKE parameters, run these commands:
 
    ```bash
    cd /root/cake-autorate     # to the cake-autorate directory
@@ -107,11 +111,15 @@ To do this:
    service cake-autorate start
    ```
 
+If you edit any of the configuration files,
+you will need to restart the service with `service cake-autorate restart`
+
 When running as a service, the `cake-autorate.sh` script outputs to
 _/var/log/cake-autorate.primary.log_ (observing the instance identifier
 _cake-autorate\_config.identifier.sh_ set in the config file name).
 
-WARNING: Take care to ensure sufficient free (Flash) memory exists in router to handle selected logging parameters.
+WARNING: Take care to ensure sufficient free (Flash) memory
+exists in router to handle selected logging parameters.
 
 ## Preserving CAKE-autorate files for backup or upgrades
 
@@ -119,18 +127,18 @@ OpenWrt devices can save files across upgrades. Read the
 [Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
 for details.
 
-Add the files below to the
+To ensure the CAKE-autorate script and configuration files are
+preserved, enter the files below to the OpenWrt router's
 [Configuration tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up)
-so they will be saved in backups and preserved across snapshot upgrades.
 
  ```bash
 /root/cake-autorate
 /etc/init.d/cake-autorate
  ```
   
-## Multi-Wan Setups
+## Multi-WAN Setups
 
-- cake-autorate has been designed to run multiple instances simultaneously.
+- CAKE-autorate has been designed to run multiple instances simultaneously.
 - cake-autorate will run one instance per config file present
 in the _/root/cake-autorate/_ directory in the form:
 
@@ -169,7 +177,8 @@ download and upload delays, relative to multiple reflectors.
 Presently this must be compiled manually (although we can expect
 an official OpenWrt package soon).
 
-Instructions for building a `tsping` OpenWrt package are available [from github.](https://github.com/Lochnair/tsping)
+Instructions for building a `tsping` OpenWrt package are available
+[from github.](https://github.com/Lochnair/tsping)
 
 ## A Request to Testers
 

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,61 +1,77 @@
 # Installing CAKE-autorate on OpenWrt
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
+bandwidth settings based on traffic load and round-trip time measurements.
 See the main [README](./README.md) page for more details of the algorithm.
 
 ## Installation Steps
 
-CAKE-autorate provides an installation script that installs all the required tools. To use it:
+CAKE-autorate provides an installation script that installs all the required tools.
+To use it:
 
-- Install SQM (`luci-app-sqm`) and enable and configure `cake` Queue Discipline on the interface(s)
-as described in the
+- Install SQM (`luci-app-sqm`) and enable and configure `cake`
+Queue Discipline on the interface(s) as described in the
 [OpenWrt SQM documentation](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
-You may have more complex networking needs: DSCPs - consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple); WireGuard with PBR - consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
+You may have more complex networking needs:
+DSCPs - consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple);
+WireGuard with PBR - consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
-- Use the installer script from this repo by copying and pasting each of the commands below:
+- Use the installer script from this repo by copying and
+pasting each of the commands below:
 
    ```bash
    wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/CAKE-autorate/master/cake-autorate_setup.sh
    
    sh /tmp/cake-autorate_setup.sh
    ```
-- The installer script will detect a previous configuration file, and ask whether to preserve it. If you do not keep it...
-- Edit the _cake-autorate\_config.primary.sh_ script (in the _/root/cake-autorate_ directory) using vi or nano to set the configuration parameters below (see comments inside _cake-autorate-config.sh_ for details). 
 
-  - Change `dl_if` and `ul_if` to match the names of the upload and download interfaces to which CAKE is applied. These can be obtained, for example, by consulting the configured SQM settings in LuCi or by examining the output of `tc qdisc ls`.
+- The installer script will detect a previous configuration file,
+and ask whether to preserve it. If you do not keep it...
+- Edit the _cake-autorate\_config.primary.sh_ script (in the
+_/root/cake-autorate_ directory) using vi or nano to set the
+configuration parameters below (see comments
+inside _cake-autorate-config.sh_ for details).
 
-      | Variable | Setting | 
-      |----: |   :-------- | 
+  - Change `dl_if` and `ul_if` to match the names of the upload and download
+  interfaces to which CAKE is applied.
+  These can be obtained, for example, by consulting the
+  configured SQM settings in LuCi or by examining the output of `tc qdisc ls`.
+
+      | Variable | Setting |
+      |----: |   :-------- |
       | `dl_if` | Interface that downloads data (often _ifb4-wan_ - check `tc qdisc ls`) |
       | `ul_if` | Interface that uploads (often _wan_) |
 
-
   - Set bandwidth variables as described in _cake-autorate\_config.primary.sh_.
- 
+
       | Type | Download | Upload |
       |----: |   :-------- | :------ |
       | Min. | `min_dl_shaper_rate_kbps` | `min_ul_shaper_rate_kbps` |
       | Base | `base_dl_shaper_rate_kbps` | `base_ul_shaper_rate_kbps` |
       | Max. | `max_dl_shaper_rate_kbps` | `max_ul_shaper_rate_kbps` |
-      
-    - Choose whether cake-autorate should adjust the shaper rates (disable for monitoring only):
+
+    - Choose whether cake-autorate should adjust the shaper rates
+    (disable for monitoring only):
   
-      | Variable | Setting | 
-      |----: |   :-------- | 
-      | `adjust_dl_shaper_rate` | enable (1) or disable (0) actually changing the dl\_shaper\_rate | 
+      | Variable | Setting |
+      |----: |   :-------- |
+      | `adjust_dl_shaper_rate` | enable (1) or disable (0) actually changing the dl\_shaper\_rate |
       | `adjust_ul_shaper_rate` | enable (1) or disable (0) actually changing the dl\_shaper\_rate |
 
-  - Set any further overrides by inspecting _cake-autorate\_defaults.sh_ and setting different values for any of the defaults. For example, to set a different `dl_delay_thr_ms`, then add a line to the config like:
+  - Set any further overrides by inspecting _cake-autorate\_defaults.sh_
+  and setting different values for any of the defaults.
+  For example, to set a different `dl_delay_thr_ms`, then
+  add a line to the config like:
   
-  ```
+  ```bash
   dl_delay_thr_ms=100
   ```
   
   - The following variables control logging:
 
-      | Variable | Setting | 
-      |----: |   :-------- | 
-      | `output_processing_stats` | If non-zero, log the results of every iteration through the process | 
+      | Variable | Setting |
+      |----: |   :-------- |
+      | `output_processing_stats` | If non-zero, log the results of every iteration through the process |
       | `output_cake_changes` | If non-zero, log when changes are made to CAKE settings via `tc` - this shows when CAKE-autorate is adjusting the shaper |
       | `debug` | If non-zero, debug lines will be output |
       | `log_to_file` | If non-zero, log lines will be sent to /tmp/cake-autorate.log regardless of whether printing to console and after every write the log file will be rotated f either `log_file_max_time_mins` have elapsed or `log_file_max_size_KB` has been exceeded |
@@ -64,19 +80,22 @@ You may have more complex networking needs: DSCPs - consider [cake-simple-qos](h
 
 ## Manual testing
 
-To start the `cake-autorate.sh` script and watch the as it adjusts the CAKE parameters, run these commands:
+To start the `cake-autorate.sh` script and watch the as it
+adjusts the CAKE parameters, run these commands:
 
    ```bash
    cd /root/cake-autorate     # to the cake-autorate directory
    ./cake-autorate.sh
    ```
 
-- Monitor the script output to see how it adjusts the download and upload rates as you use the connection.
+- Monitor the script output to see how it adjusts the
+download and upload rates as you use the connection.
 - Press ^C to halt the process.
 
 ## Install as a service
 
-You can install CAKE-autorate as a service that starts up the autorate process whenever the router reboots.
+You can install CAKE-autorate as a service that starts up
+the autorate process whenever the router reboots.
 To do this:
 
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
@@ -88,29 +107,34 @@ To do this:
    service cake-autorate start
    ```
 
-When running as a service, the `cake-autorate.sh` script outputs to _/var/log/cake-autorate.primary.log_ (observing the instance identifier _cake-autorate\_config.identifier.sh_ set in the config file name). 
+When running as a service, the `cake-autorate.sh` script outputs to
+_/var/log/cake-autorate.primary.log_ (observing the instance identifier
+_cake-autorate\_config.identifier.sh_ set in the config file name).
 
 WARNING: Take care to ensure sufficient free (Flash) memory exists in router to handle selected logging parameters.
 
 ## Preserving CAKE-autorate files for backup or upgrades
 
-The [Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
-describes how files can be saved across upgrades. 
+OpenWrt devices can save files across upgrades. Read the
+[Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
+for details.
 
-[Add these files on the **Configuration** tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up),
+Add the files below to the
+[Configuration tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up)
 so they will be saved in backups and preserved across snapshot upgrades.
 
- ```
+ ```bash
 /root/cake-autorate
 /etc/init.d/cake-autorate
  ```
   
 ## Multi-Wan Setups
 
-- cake-autorate has been designed to run multiple instances simultaneously. 
-- cake-autorate will run one instance per config file present in the _/root/cake-autorate/_ directory in the form:
+- cake-autorate has been designed to run multiple instances simultaneously.
+- cake-autorate will run one instance per config file present
+in the _/root/cake-autorate/_ directory in the form:
 
-```
+```bash
 cake-autorate_config.interface.sh
 ```
 
@@ -118,22 +142,37 @@ where 'interface' is replaced with e.g. 'primary', 'secondary', etc.
 
 ## Example Starlink Configuration
 
-- OpenWrt forum member @gba has kindly shared [his Starlink config](Example_Starlink_config.sh).
-  This ought to provide some helpful pointers for adding appropriate overrides for Starlink users.
-- See discussion on OpenWrt thread from [around this post](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/3100?u=lynx).
+- OpenWrt forum member @gba has kindly shared
+[his Starlink config](Example_Starlink_config.sh).
+This ought to provide some helpful pointers for adding
+appropriate overrides for Starlink users.
+- See discussion on OpenWrt thread from
+[around this post](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/3100?u=lynx).
 
 ## Selecting a "ping binary"
 
-CAKE-autorate reads the `$pinger_binary` variable in the config file to select the ping binary. Choices include:
+CAKE-autorate reads the `$pinger_binary` variable in the
+config file to select the ping binary. Choices include:
 
-- **fping** (DEFAULT) round robin pinging to multiple reflectors with tightly controlled timings 
-- **tsping** round robin ICMP type 13 pinging to multiple reflectors with tightly controlled timings 
-- **iputils-ping** more advanced pinging than the default busybox ping with sub 1s ping frequency
+- **fping** (DEFAULT) round robin pinging to multiple
+reflectors with tightly controlled timings
+- **tsping** round robin ICMP type 13 pinging to multiple
+reflectors with tightly controlled timings
+- **iputils-ping** more advanced pinging than the default
+busybox ping with sub 1s ping frequency
 
-**About tsping** @Lochnair has coded up an elegant ping utility in C that sends out ICMP type 13 requests in a round robin manner, thereby facilitating determination of one way delays (OWDs), i.e. not just round trip time (RTT), but the constituent download and upload delays, relative to multiple reflectors. Presently this must be compiled manually (although we can expect an official OpenWrt package soon). 
+**About tsping** @Lochnair has coded up an elegant ping utility in C
+that sends out ICMP type 13 requests in a round robin manner,
+thereby facilitating determination of one way delays (OWDs),
+i.e. not just round trip time (RTT), but the constituent
+download and upload delays, relative to multiple reflectors.
+Presently this must be compiled manually (although we can expect
+an official OpenWrt package soon).
 
 Instructions for building a `tsping` OpenWrt package are available [from github.](https://github.com/Lochnair/tsping)
 
 ## A Request to Testers
 
-If you use this script, please post your experience on this [OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/). Your feedback will help improve the script for the benefit of others.  
+If you use this script, please post your experience on this
+[OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/).
+Your feedback will help improve the script for the benefit of others.  

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,139 @@
+# Installing CAKE-autorate on OpenWrt
+
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements.
+See the main [README](./README.md) page for more details of the algorithm.
+
+## Installation Steps
+
+CAKE-autorate provides an installation script that installs all the required tools. To use it:
+
+- Install SQM (`luci-app-sqm`) and enable and configure `cake` Queue Discipline on the interface(s)
+as described in the
+[OpenWrt SQM documentation](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
+You may have more complex networking needs: DSCPs - consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple); WireGuard with PBR - consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
+- [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
+- Use the installer script from this repo by copying and pasting each of the commands below:
+
+   ```bash
+   wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/CAKE-autorate/master/cake-autorate_setup.sh
+   
+   sh /tmp/cake-autorate_setup.sh
+   ```
+- The installer script will detect a previous configuration file, and ask whether to preserve it. If you do not keep it...
+- Edit the _cake-autorate\_config.primary.sh_ script (in the _/root/cake-autorate_ directory) using vi or nano to set the configuration parameters below (see comments inside _cake-autorate-config.sh_ for details). 
+
+  - Change `dl_if` and `ul_if` to match the names of the upload and download interfaces to which CAKE is applied. These can be obtained, for example, by consulting the configured SQM settings in LuCi or by examining the output of `tc qdisc ls`.
+
+      | Variable | Setting | 
+      |----: |   :-------- | 
+      | `dl_if` | Interface that downloads data (often _ifb4-wan_ - check `tc qdisc ls`) |
+      | `ul_if` | Interface that uploads (often _wan_) |
+
+
+  - Set bandwidth variables as described in _cake-autorate\_config.primary.sh_.
+ 
+      | Type | Download | Upload |
+      |----: |   :-------- | :------ |
+      | Min. | `min_dl_shaper_rate_kbps` | `min_ul_shaper_rate_kbps` |
+      | Base | `base_dl_shaper_rate_kbps` | `base_ul_shaper_rate_kbps` |
+      | Max. | `max_dl_shaper_rate_kbps` | `max_ul_shaper_rate_kbps` |
+      
+    - Choose whether cake-autorate should adjust the shaper rates (disable for monitoring only):
+  
+      | Variable | Setting | 
+      |----: |   :-------- | 
+      | `adjust_dl_shaper_rate` | enable (1) or disable (0) actually changing the dl\_shaper\_rate | 
+      | `adjust_ul_shaper_rate` | enable (1) or disable (0) actually changing the dl\_shaper\_rate |
+
+  - Set any further overrides by inspecting _cake-autorate\_defaults.sh_ and setting different values for any of the defaults. For example, to set a different `dl_delay_thr_ms`, then add a line to the config like:
+  
+  ```
+  dl_delay_thr_ms=100
+  ```
+  
+  - The following variables control logging:
+
+      | Variable | Setting | 
+      |----: |   :-------- | 
+      | `output_processing_stats` | If non-zero, log the results of every iteration through the process | 
+      | `output_cake_changes` | If non-zero, log when changes are made to CAKE settings via `tc` - this shows when CAKE-autorate is adjusting the shaper |
+      | `debug` | If non-zero, debug lines will be output |
+      | `log_to_file` | If non-zero, log lines will be sent to /tmp/cake-autorate.log regardless of whether printing to console and after every write the log file will be rotated f either `log_file_max_time_mins` have elapsed or `log_file_max_size_KB` has been exceeded |
+      | `log_file_max_time_mins` | Number of minutes to elapse between log file rotaton |
+      | `log_file_max_size_KB` | Number of KB (i.e. bytes/1024) worth of log lines between log file rotations |
+
+## Manual testing
+
+To start the `cake-autorate.sh` script and watch the as it adjusts the CAKE parameters, run these commands:
+
+   ```bash
+   cd /root/cake-autorate     # to the cake-autorate directory
+   ./cake-autorate.sh
+   ```
+
+- Monitor the script output to see how it adjusts the download and upload rates as you use the connection.
+- Press ^C to halt the process.
+
+## Install as a service
+
+You can install CAKE-autorate as a service that starts up the autorate process whenever the router reboots.
+To do this:
+
+- [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
+- Run these commands to enable and start the service file:
+
+   ```bash
+   # the cake-autorate-setup.sh script already installed the service file
+   service cake-autorate enable
+   service cake-autorate start
+   ```
+
+When running as a service, the `cake-autorate.sh` script outputs to _/var/log/cake-autorate.primary.log_ (observing the instance identifier _cake-autorate\_config.identifier.sh_ set in the config file name). 
+
+WARNING: Take care to ensure sufficient free (Flash) memory exists in router to handle selected logging parameters.
+
+## Preserving CAKE-autorate files for backup or upgrades
+
+The [Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
+describes how files can be saved across upgrades. 
+
+[Add these files on the **Configuration** tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up),
+so they will be saved in backups and preserved across snapshot upgrades.
+
+ ```
+/root/cake-autorate
+/etc/init.d/cake-autorate
+ ```
+  
+## Multi-Wan Setups
+
+- cake-autorate has been designed to run multiple instances simultaneously. 
+- cake-autorate will run one instance per config file present in the _/root/cake-autorate/_ directory in the form:
+
+```
+cake-autorate_config.interface.sh
+```
+
+where 'interface' is replaced with e.g. 'primary', 'secondary', etc.
+
+## Example Starlink Configuration
+
+- OpenWrt forum member @gba has kindly shared [his Starlink config](Example_Starlink_config.sh).
+  This ought to provide some helpful pointers for adding appropriate overrides for Starlink users.
+- See discussion on OpenWrt thread from [around this post](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/3100?u=lynx).
+
+## Selecting a "ping binary"
+
+CAKE-autorate reads the `$pinger_binary` variable in the config file to select the ping binary. Choices include:
+
+- **fping** (DEFAULT) round robin pinging to multiple reflectors with tightly controlled timings 
+- **tsping** round robin ICMP type 13 pinging to multiple reflectors with tightly controlled timings 
+- **iputils-ping** more advanced pinging than the default busybox ping with sub 1s ping frequency
+
+**About tsping** @Lochnair has coded up an elegant ping utility in C that sends out ICMP type 13 requests in a round robin manner, thereby facilitating determination of one way delays (OWDs), i.e. not just round trip time (RTT), but the constituent download and upload delays, relative to multiple reflectors. Presently this must be compiled manually (although we can expect an official OpenWrt package soon). 
+
+Instructions for building a `tsping` OpenWrt package are available [from github.](https://github.com/Lochnair/tsping)
+
+## A Request to Testers
+
+If you use this script, please post your experience on this [OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/). Your feedback will help improve the script for the benefit of others.  

--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@
 
 Present version is 2.0.0 - please see [the changelog](CHANGELOG.md) for details.
 
-## The Problem: CAKE on variable speed connections forces an Unpalatable Compromise
+## The Problem: CAKE on variable speed connections forces an unpalatable compromise
 
 The CAKE algorithm uses static upload and download bandwidth settings to manage its queues. Variable bandwidth connections present a challenge because the actual bandwidth at any given moment is not known.
 
-Because CAKE works with fixed speed parameters,  the user must choose a single compromise bandwidth setting. This compromise is not ideal: setting the parameter too low means
-the connection is unnecessarily throttled to the compromise setting even when the available link speed is higher (yellow). Setting the rate too high, for times when the usable line rate falls below the compromise value, the link is not throttled enough (green) resulting in bufferbloat.
+Because CAKE works with fixed bandwidth parameters,  the user must choose a single compromise bandwidth setting. This compromise is not ideal: setting the parameter too low means the connection is unnecessarily throttled to the compromise setting even when the available link speed is higher (yellow). Setting the rate too high, for times when the usable line rate falls below the compromise value, means that the link is not throttled enough (green) resulting in bufferbloat.
 
 <img src="images/bandwidth-compromise.png" width=75% height=75%>
 
@@ -25,11 +24,9 @@ The CAKE-autorate script continually measures the load and One Way Delay or Roun
 
 CAKE-autorate uses this simple approach:
 
-- with low load, decay rate back to the configured baseline
-(and subject to refractory period)
+- with low load, decay rate back to the configured baseline (and subject to refractory period)
 - with high load, increase rate subject to the configured maximum
-- if bufferbloat (increased latency) is detected, decrease rate subject
-to the configured min (and subject to refractory period)
+- if bufferbloat (increased latency) is detected, decrease rate subject to the configured min (and subject to refractory period)
 
 <img src="images/cake-bandwidth-autorate-rate-control.png" width=80% height=80%>
 
@@ -63,7 +60,7 @@ CAKE-autorate maintains a detailed log file thats is helpful in discerning perfo
 
 ## Optimizations
 
-CAKE-autorate uses inter-process communication between multiple concurrent processes to dramatically decrease the CPU required to perform its many tasks. The `ps |grep -e bash -e fping` shows the many tasks running:
+CAKE-autorate uses inter-process communication between multiple concurrent processes and incorporates various optimisations to reduce the CPU load nedded to perform its many tasks. A call to `ps |grep -e bash -e fping` reveals the presence of the multiple concurrent processes for each cake-autorate instance. This is normal and expected behaviour. 
 
 ```bash
 root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **CAKE-autorate** is a script that minimizes latency by adjusting CAKE
 bandwidth settings based on traffic load and round-trip time measurements.
-This is intended for variable bandwidth connections such as
+CAKE-autorate is intended for variable bandwidth connections such as
 LTE, Starlink, and cable modems and is not generally required
 for use on connections that have a stable, fixed bandwidth.
 
@@ -14,23 +14,21 @@ and improving the responsiveness of a network.
 
 Present version is 2.1.0 - please see [the changelog](CHANGELOG.md) for details.
 
-## The Problem: CAKE on Variable Speed Connections forces an Unpalatable Compromise
+## The Problem: CAKE on variable speed connections forces an Unpalatable Compromise
 
-The CAKE algorithm works from fixed upload and download bandwidth
+The CAKE algorithm uses static upload and download bandwidth
 settings to manage its queues.
 Variable bandwidth connections present a challenge because
 the actual bandwidth at any given moment is not known.
 
-Because CAKE works with fixed speed parameters the user must choose
-a compromise bandwidth setting.
-Setting it too low means lost bandwidth in exchange for latency control;
-setting the parameter too high induces bufferbloat when the link slows down.
-
-This compromise is not ideal: when the usable line rate is above the
-set compromise bandwidth, the connection is unnecessarily throttled
-to the compromise setting resulting in lost bandwidth (yellow);
-when the usable line rate falls below the compromise value,
-the connection is not throttled enough (green) resulting in bufferbloat.
+Because CAKE works with fixed speed parameters, 
+the user must choose a single compromise bandwidth setting.
+This compromise is not ideal: setting the parameter too low means
+the connection is unnecessarily throttled to the compromise
+setting even when the available link speed is higher (yellow).
+Setting the rate too high, for times when the
+usable line rate falls below the compromise value,
+the link is not throttled enough (green) resulting in bufferbloat.
 
 <img src="images/bandwidth-compromise.png" width=75% height=75%>
 
@@ -40,21 +38,24 @@ The CAKE-autorate script continually measures the load and
 Round-Trip-Time (RTT) to adjust the upload and download settings
 for the CAKE algorithm.
 
-## Theory of Operation
+### Theory of Operation
 
-`cake-autorate.sh` monitors load (rx and tx utilization) and ping responses
-from one or more reflectors, and adjusts the download and upload
-bandwidth settings for CAKE.
-Rate control is intentionally kept as simple as possible and follows
-the following approach:
+`cake-autorate.sh` monitors load (receive and transmit utilization)
+and ping response times from one or more reflectors
+(hosts on the internet),
+and adjusts the download and upload bandwidth settings for CAKE.
+CAKE-autorate uses this simple approach:
 
 - with low load, decay rate back to the configured baseline
 (and subject to refractory period)
 - with high load, increase rate subject to the configured maximum
-- on bufferbloat (when increased latency is detected), decrease rate subject
+- if bufferbloat (increased latency) is detected, decrease rate subject
 to the configured min (and subject to refractory period)
 
 <img src="images/cake-bandwidth-autorate-rate-control.png" width=80% height=80%>
+
+CAKE-autorate requires three configuration values for each direction,
+upload and download:
 
 **Setting the minimum bandwidth:**
 Set the minimum value to the worst possible observed bufferbloat-free bandwidth.
@@ -68,13 +69,13 @@ the value you would set CAKE to that is bufferbloat free most,
 but not necessarily all, of the time.
 
 **Setting the maximum bandwidth:**
-The maximum bandwidth should be set to the lower of the maximum bandwidth
-that the ISP can provide or the maximum bandwidth required by the user.
-The script will adjust the bandwidth up when there is traffic,
-as long no RTT spike is detected.
-Setting this value to a maximum required level will have the advantage that
-the script will stay at that level during optimum conditions rather than
-always having to test whether the bandwidth can be increased
+The maximum bandwidth should be set to the maximum bandwidth
+that the ISP can provide.
+When there is heavy traffic, the script will adjust the
+bandwidth up to this limit,
+and then back off if a RTT spike is detected.
+The script will tend to remain at that level during low latency
+rather than always testing whether the bandwidth can be increased
 (which necessarily results in allowing some excess latency through).
 
 To elaborate on setting the minimum and maximum, a variable bandwidth connection
@@ -96,7 +97,7 @@ There is a detailed and fun discussion with plenty of sketches relating to the
 development of the script and alternatives on the
 [OpenWrt Forum - CAKE /w Adaptive Bandwidth.](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/312)
 
-## Installation
+## Installation on OpenWrt
 
 Read the installation instructions in the separate
 [INSTALLATION](./INSTALLATION.md) page.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,28 @@
 # CAKE with Adaptive Bandwidth - "autorate"
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
-bandwidth settings based on traffic load and round-trip time measurements.
-CAKE-autorate is intended for variable bandwidth connections such as
-LTE, Starlink, and cable modems and is not generally required
-for use on connections that have a stable, fixed bandwidth.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. CAKE-autorate is intended for variable bandwidth connections such as LTE, Starlink, and cable modems and is not generally required for use on connections that have a stable, fixed bandwidth.
 
-[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/)
-is an algorithm that manages the buffering of data being sent/received by a device
-such as an [OpenWrt router](https://openwrt.org)
-so that no more data is queued than is necessary, minimizing the latency ("bufferbloat")
-and improving the responsiveness of a network.
+[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/) is an algorithm that manages the buffering of data being sent/received by a device such as an [OpenWrt router](https://openwrt.org) so that no more data is queued than is necessary, minimizing the latency ("bufferbloat") and improving the responsiveness of a network.
 
-Present version is 2.1.0 - please see [the changelog](CHANGELOG.md) for details.
+Present version is 2.0.0 - please see [the changelog](CHANGELOG.md) for details.
 
 ## The Problem: CAKE on variable speed connections forces an Unpalatable Compromise
 
-The CAKE algorithm uses static upload and download bandwidth
-settings to manage its queues.
-Variable bandwidth connections present a challenge because
-the actual bandwidth at any given moment is not known.
+The CAKE algorithm uses static upload and download bandwidth settings to manage its queues. Variable bandwidth connections present a challenge because the actual bandwidth at any given moment is not known.
 
-Because CAKE works with fixed speed parameters, 
-the user must choose a single compromise bandwidth setting.
-This compromise is not ideal: setting the parameter too low means
-the connection is unnecessarily throttled to the compromise
-setting even when the available link speed is higher (yellow).
-Setting the rate too high, for times when the
-usable line rate falls below the compromise value,
-the link is not throttled enough (green) resulting in bufferbloat.
+Because CAKE works with fixed speed parameters,  the user must choose a single compromise bandwidth setting. This compromise is not ideal: setting the parameter too low means
+the connection is unnecessarily throttled to the compromise setting even when the available link speed is higher (yellow). Setting the rate too high, for times when the usable line rate falls below the compromise value, the link is not throttled enough (green) resulting in bufferbloat.
 
 <img src="images/bandwidth-compromise.png" width=75% height=75%>
 
 ## The Solution: Set CAKE parameters based on _Load_ and _RTT_
 
-The CAKE-autorate script continually measures the load and
-Round-Trip-Time (RTT) to adjust the upload and download settings
-for the CAKE algorithm.
+The CAKE-autorate script continually measures the load and One Way Delay or Round-Trip-Time (RTT) to adjust the upload and download settings for the CAKE algorithm.
 
 ### Theory of Operation
 
-`cake-autorate.sh` monitors load (receive and transmit utilization)
-and ping response times from one or more reflectors
-(hosts on the internet),
-and adjusts the download and upload bandwidth settings for CAKE.
+`cake-autorate.sh` monitors load (receive and transmit utilization) and ping response times from one or more reflectors (hosts on the internet), and adjusts the download and upload bandwidth settings for CAKE.
+
 CAKE-autorate uses this simple approach:
 
 - with low load, decay rate back to the configured baseline
@@ -54,65 +33,37 @@ to the configured min (and subject to refractory period)
 
 <img src="images/cake-bandwidth-autorate-rate-control.png" width=80% height=80%>
 
-CAKE-autorate requires three configuration values for each direction,
-upload and download:
+CAKE-autorate requires three configuration values for each direction, upload and download.
 
 **Setting the minimum bandwidth:**
-Set the minimum value to the worst possible observed bufferbloat-free bandwidth.
-Ideally this setting should never result in bufferbloat even under the worst conditions.
-This is a hard minimum - the script will never reduce the bandwidth below this level.
+Set the minimum value to the worst possible observed bufferbloat-free bandwidth. Ideally this setting should never result in bufferbloat even under the worst conditions. This is a hard minimum - the script will never reduce the bandwidth below this level.
 
 **Setting the baseline bandwidth:**
-This is the steady state bandwidth to be maintained under no or low load.
-This is likely the compromise bandwidth described above, i.e.
-the value you would set CAKE to that is bufferbloat free most,
-but not necessarily all, of the time.
+This is the steady state bandwidth to be maintained under no or low load. This is likely the compromise bandwidth described above, i.e. the value you would set CAKE to that is bufferbloat free most, but not necessarily all, of the time.
 
 **Setting the maximum bandwidth:**
-The maximum bandwidth should be set to the maximum bandwidth
-that the ISP can provide.
-When there is heavy traffic, the script will adjust the
-bandwidth up to this limit,
-and then back off if a RTT spike is detected.
-The script will tend to remain at that level during low latency
-rather than always testing whether the bandwidth can be increased
-(which necessarily results in allowing some excess latency through).
+The maximum bandwidth should be set to the maximum bandwidth that the ISP can provide. When there is heavy traffic, the script will adjust the bandwidth up to this limit,
+and then back off if a RTT spike is detected. The script will tend to remain at that level during low latency rather than always testing whether the bandwidth can be increased (which necessarily results in allowing some excess latency through).
 
-To elaborate on setting the minimum and maximum, a variable bandwidth connection
-may be most ideally divided up into a known fixed, stable component,
-on top of which is provided an unknown variable component:
+To elaborate on setting the minimum and maximum, a variable bandwidth connection may be most ideally divided up into a known fixed, stable component, on top of which is provided an unknown variable component:
 
 ![image of cake bandwidth adaptation](images/cake-bandwidth-adaptation.png)
 
-The minimum bandwidth is then set to (or slightly below) the fixed component,
-and the maximum bandwidth may be set to (or slightly above)
-the maximum observed bandwidth.
-Or, if a lower maximum bandwidth is required by the user,
-the maximum bandwidth is set to that lower bandwidth as explained above.
+The minimum bandwidth is then set to (or slightly below) the fixed component, and the maximum bandwidth may be set to (or slightly above) the maximum observed bandwidth. Or, if a lower maximum bandwidth is required by the user, the maximum bandwidth is set to that lower bandwidth as explained above.
 
-The baseline bandwidth is likely optimally either the minimum bandwidth
-or somewhere close thereto (e.g. the compromise bandwidth).
-
-There is a detailed and fun discussion with plenty of sketches relating to the
-development of the script and alternatives on the
-[OpenWrt Forum - CAKE /w Adaptive Bandwidth.](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/312)
+The baseline bandwidth is likely optimally either the minimum bandwidth or somewhere close thereto (e.g. the compromise bandwidth).
 
 ## Installation on OpenWrt
 
-Read the installation instructions in the separate
-[INSTALLATION](./INSTALLATION.md) page.
+Read the installation instructions in the separate [INSTALLATION](./INSTALLATION.md) page.
 
 ## Analysis of the CAKE-autorate logs
 
-CAKE-autorate keeps a number of log files that help to analyze its performance.
-Read about them in the [ANALYSIS](./ANALYSIS.md) page.
+CAKE-autorate maintains a detailed log file thats is helpful in discerning performance. Read about this in the [ANALYSIS](./ANALYSIS.md) page.
 
 ## Optimizations
 
-CAKE-autorate uses inter-process communication between
-multiple concurrent processes to dramatically decrease
-the CPU required to perform its many tasks.
-The `ps |grep -e bash -e fping` shows the many tasks running:
+CAKE-autorate uses inter-process communication between multiple concurrent processes to dramatically decrease the CPU required to perform its many tasks. The `ps |grep -e bash -e fping` shows the many tasks running:
 
 ```bash
 root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
@@ -127,9 +78,3 @@ root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
  2840 root      3308 S    {cake-autorate.s} /bin/bash /root/cake-autorate/cake-autorate.sh /root/cake-autorate/cake-autorate_config.pri
  2841 root      1928 S    fping --timestamp --loop --period 300 --interval 50 --timeout 10000 1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4 9.9.9.9 9
 ```
-
-## A Request to Testers
-
-If you use this script, please post your experience on this
-[OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/).
-Your feedback will help improve the script for the benefit of others.  

--- a/README.md
+++ b/README.md
@@ -1,35 +1,37 @@
 # CAKE with Adaptive Bandwidth - "autorate"
 
-**CAKE-autorate** is a script that automatically adapts [CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/) bandwidth settings by measuring traffic load and RTT times. This is designed for variable bandwidth connections such as LTE, and is not intended for use on connections that have a stable, fixed bandwidth.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. This is intended for variable bandwidth connections such as LTE, Starlink, and cable modems and is not generally required for use on connections that have a stable, fixed bandwidth.
 
-CAKE is an algorithm that manages the buffering of data being sent/received by a device such as an [OpenWrt router](https://openwrt.org) so that no more data is queued than is necessary, minimizing the latency ("bufferbloat") and improving the responsiveness of a network.
+[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/) is an algorithm that manages the buffering of data being sent/received by a device such as an [OpenWrt router](https://openwrt.org) so that no more data is queued than is necessary, minimizing the latency ("bufferbloat") and improving the responsiveness of a network.
 
-Present version is 2.0.0 - please see [the changelog](CHANGELOG.md) for details. 
+Present version is 2.1.0 - please see [the changelog](CHANGELOG.md) for details. 
 
-## The Problem: CAKE on Variable Connections forces an Unpalatable Compromise
+## The Problem: CAKE on Variable Speed Connections forces an Unpalatable Compromise
 
-The CAKE algorithm always uses fixed upload and download bandwidth settings to manage its queues. Variable bandwidth connections present a challenge because the actual bandwidth at any given moment is not known. 
+The CAKE algorithm works from fixed upload and download bandwidth settings to manage its queues. Variable bandwidth connections present a challenge because the actual bandwidth at any given moment is not known. 
 
-As CAKE works with a fixed set bandwidth this effectively forces the user to choose a compromise bandwidth setting, but typically this means lost bandwidth in exchange for latency control and/or bufferbloat during the worst conditions. This compromise is hardly ideal: whilst the actual usable line rate is above the set compromise bandwidth, the connection is unnecessarily throttled back to the compromise setting resulting in lost bandwidth (yellow); and whilst the actual usable line rate is below the compromise value, the connection is not throttled enough (green) resulting in bufferbloat.
+Because CAKE works with fixed speed parameters the user must choose a compromise bandwidth setting. Setting it too low means lost bandwidth in exchange for latency control; setting the parameter too high induces bufferbloat when the link slows down.
+
+This compromise is not ideal: when the usable line rate is above the set compromise bandwidth, the connection is unnecessarily throttled to the compromise setting resulting in lost bandwidth (yellow); when the usable line rate falls below the compromise value, the connection is not throttled enough (green) resulting in bufferbloat.
 
 <img src="images/bandwidth-compromise.png" width=75% height=75%>
 
-## The Solution: Automatic Bandwidth Adjustment based on LOAD and RTT
+## The Solution: Set CAKE parameters based on _Load_ and _RTT_
 
-The **cake-autorate.sh** script periodically measures the load and Round-Trip-Time (RTT) to adjust the upload and download values for the CAKE algorithm.
+The CAKE-autorate script continually measures the load and Round-Trip-Time (RTT) to adjust the upload and download settings for the CAKE algorithm.
 
 ## Theory of Operation
 
-`cake-autorate.sh` monitors load (rx and tx) and ping respones from one or more reflectors, and adjusts the download and upload bandwidth for CAKE. Rate control is intentionally kept as simple as possible and follows the following approach:
+`cake-autorate.sh` monitors load (rx and tx utilization) and ping responses from one or more reflectors, and adjusts the download and upload bandwidth settings for CAKE. Rate control is intentionally kept as simple as possible and follows the following approach:
 
-- with low load, decay rate back to set baseline (and subject to refractory period)
-- with high load, increase rate subject to set maximum
-- on bufferbloat, decrease rate subject to set min (and subject to refractory period)
+- with low load, decay rate back to the configured baseline (and subject to refractory period)
+- with high load, increase rate subject to the configured maximum
+- on bufferbloat (when increased latency is detected), decrease rate subject to the configured min (and subject to refractory period)
 
 <img src="images/cake-bandwidth-autorate-rate-control.png" width=80% height=80%>
 
 **Setting the minimum bandwidth:** 
-Set the minimum value to the worst possible observed bufferbloat free bandwidth. Ideally this CAKE bandwidth should never result in bufferbloat even under the worst conditions. This is a hard minimum - the script will never reduce the bandwidth below this level.
+Set the minimum value to the worst possible observed bufferbloat-free bandwidth. Ideally this CAKE bandwidth should never result in bufferbloat even under the worst conditions. This is a hard minimum - the script will never reduce the bandwidth below this level.
 
 **Setting the baseline bandwidth:** 
 This is the steady state bandwidth to be maintained under no or low load. This is likely the compromise bandwidth described above, i.e. the value you would set CAKE to that is bufferbloat free most, but not necessarily all, of the time. 
@@ -48,192 +50,21 @@ The baseline bandwidth is likely optimally either the minimum bandwidth or somew
 There is a detailed and fun discussion with plenty of sketches relating to the development of the script and alternatives on the
 [OpenWrt Forum - CAKE /w Adaptive Bandwidth.](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/312)
 
-## Required packages
+## Installation
 
-Only requires:
+Read the installation instructions in the separate [INSTALLATION](./INSTALLATION.md) page.
 
-- **bash** for its builtins, arithmetic and array handling
+## Analysis of the CAKE-autorate logs
 
-A pinger binary chosen from:
+CAKE-autorate keeps a number of log files that help to analyze its performance.
+Read about them in the [ANALYSIS](./ANALYSIS.md) page.
 
-- **fping** round robin pinging to multiple reflectors with tightly controlled timings (default)
-- **tsping** round robin ICMP type 13 pinging to multiple reflectors with tightly controlled timings 
-- **iputils-ping** more advanced pinging than the default busybox ping with sub 1s ping frequency
+## Optimizations
 
-The pinger binary that cake-autorate uses is set using the $pinger_binary variable in the config file. 
-
-## Installation on OpenWrt
-
-- Install SQM (`luci-app-sqm`) and enable CAKE on the interface(s)
-as described in the
-[OpenWrt SQM documentation](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
-- Alternatively, and if you want to work with DSCPs, consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple) or for unusual setups such as those with WireGuard with PBR, then you may want to consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
-- [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
-- It is recommended to install cake-autorate using the installer script from this repo, e.g. by copying and pasting each of the commands below:
-
-   ```bash
-   wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/CAKE-autorate/master/cake-autorate_setup.sh
-   sh /tmp/cake-autorate_setup.sh
-   ```
-- The installer script will detect a previous configuration file, and ask whether to preserve it. If you do not keep it...
-- Edit the `cake-autorate-config.primary.sh` script (in the `/root/cake-autorate` directory) using vi or nano to set the configuration parameters below (see comments inside `cake-autorate-config.sh` for details). 
-
-  - Change `ul_if` and `dl_if` to match the names of the upload and download interfaces to which CAKE is applied. These can be obtained, for example, by consulting the configured SQM settings in LuCi or by examining the output of `tc qdisc ls`.
-
-      | Variable | Setting | 
-      |----: |   :-------- | 
-      | `ul_if` | Interface that uploads (often `wan`) |
-      | `dl_if` | Interface that uploads data (check `tc qdisc ls`) |
-
-  - Choose whether to have cake-autorate actually adjust the shaper rates (disable for monitoring only):
-  
-      | Variable | Setting | 
-      |----: |   :-------- | 
-      | `adjust_dl_shaper_rate` | enable (1) or disable (0) actually changing the dl_shaper_rate | 
-      | `adjust_ul_shaper_rate` | enable (1) or disable (0) actually changing the dl_shaper_rate |
-
-  - Set bandwidth variables as described in `cake-autorate-config.sh`.
- 
-      | Type | Download | Upload |
-      |----: |   :-------- | :------ |
-      | Min. | `min_dl_shaper_rate_kbps` | `min_ul_shaper_rate_kbps` |
-      | Base | `base_dl_shaper_rate_kbps` | `base_ul_shaper_rate_kbps` |
-      | Max. | `max_dl_shaper_rate_kbps` | `max_ul_shaper_rate_kbps` |
-      
-  - Set any further overrides by inspecting 'cake-autorate_defaults.sh' and setting different values for any of the defaults. For example, to set a different dl_delay_thr_ms, then add a line to the config like:
-  
-  ```
-  dl_delay_thr_ms=100
-  ```
-  
-  - The following variables control logging:
-
-      | Variable | Setting | 
-      |----: |   :-------- | 
-      | `output_processing_stats` | If non-zero, log the results of every iteration through the process | 
-      | `output_cake_changes` | If non-zero, log when changes are made to CAKE settings via `tc` - this shows when CAKE-autorate is adjusting the shaper |
-      | `debug` | If non-zero, debug lines will be output |
-      | `log_to_file` | If non-zero, log lines will be sent to /tmp/cake-autorate.log regardless of whether printing to console and after every write the log file will be rotated f either `log_file_max_time_mins` have elapsed or `log_file_max_size_KB` has been exceeded |
-      | `log_file_max_time_mins` | Number of minutes to elapse between log file rotaton |
-      | `log_file_max_size_KB` | Number of KB (i.e. bytes/1024) worth of log lines between log file rotations |
-  
-## tsping ## 
-
-@Lochnair has coded up an elegant ping utility in C that sends out ICMP type 13 requests in a round robin manner, thereby facilitating determination of one way delays (OWDs), i.e. not just round trip time (RTT), but the constituent download and upload delays, relative to multiple reflectors. Presently this must be compiled manually (although we can expect an official OpenWrt package soon). 
-
-tsping is available (together with instructions for building an OpenWrt package) here:
-
-https://github.com/Lochnair/tsping
-
-## Exporting a Log File ##
-
-A compressed log file can be extracted from a running cake-autorate instance using one of either two methods:
-
-- **1) by running the auto-generated log_file_export script inside the run directory:**
-
-```bash
-/var/run/cake-autorate/*/log_file_export
-```
-
-or
-
-- **2) by sending a USR1 signal to the maintain log file process using:**
-
-```bash
-kill -USR1 $(cat /var/run/cake-autorate/*/proc_state | grep -E '^maintain_log_file=' | cut -d= -f2)
-```
-
-This will place a compressed log file in /var/log with the date and time in its filename.
-
-## Rotating the Log File ##
-
-Similarly, a log file rotation can be requested on a running cake-autorate instance by using one of either two methods
-
-- **1) by running the auto-generated log_file_rotate script inside the run directory:**
-
-```bash
-/var/run/cake-autorate/*/log_file_rotate
-```
-or
-
-- **2) by sending a USR2 signal to the maintain log file process using:**
-
-```bash
-kill -USR2 $(cat /var/run/cake-autorate/*/proc_state | grep -E '^maintain_log_file=' | cut -d= -f2)
-```
-
-## Plotting the Log File ##
-
-A very helpful summary plot like this: 
-
-<img src="https://user-images.githubusercontent.com/10721999/194724668-d8973bb6-5a37-4b05-a212-3514db8f56f1.png" width=80% height=80%>
-
-can be created from an exported log file using the excellent Octave/Matlab utility put together by @moeller0 of OpenWrt, using something like:
- 
- ```bash
- octave -qf --eval 'fn_parse_autorate_log("./log.gz", "./output.pdf")'
-```
-(see the introductory notes in 'fn_parse_autorate_log.m' for more details).
-
-Here is an example script to extract the log from the router and generate the pdfs for viewing from a client machine:
-
-```bash
-log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"
-octave -qf --eval 'fn_parse_autorate_log("./*primary*log.gz", "./output.pdf")'
-```
-
-## Multi-Wan Setups
-
-- cake-autorate has been designed to run multiple instances simultaneously. 
-- cake-autorate will run one instance per config file present in the /root/cake-autorate/ directory in the form:
-
-```
-cake-autorate_config.interface.sh
-```
-
-where 'interface' is replaced with e.g. 'primary', 'secondary', etc.
-
-## Example Starlink Configuration
-
-- OpenWrt forum member @gba has kindly shared [his Starlink config](Example_Starlink_config.sh).
-  This ought to provide some helpful pointers for adding appropriate overrides for Starlink users.
-- See discussion on OpenWrt thread from [around this post](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/3100?u=lynx).
-
-## Manual testing
-
-To run the `cake-autorate.sh` script:
-
-- run:
-
-   ```bash
-   cd /root/cake-autorate # to the cake-autorate directory
-   ./cake-autorate.sh
-   ```
-
-- Monitor the script output to see how it adjusts the download and upload rates as you use the connection.
-- Press ^C to halt the process.
-
-## Install as a service
-
-You can install this as a service that starts up the autorate process whenever the router reboots.
-To do this:
-
-- [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
-- Run these commands to enable and start the service file:
-
-   ```bash
-   # the cake-autorate-setup.sh script already installed the service file
-   service cake-autorate enable
-   service cake-autorate start
-   ```
-
-When running as a service, the `cake-autorate.sh` script outputs to `/var/log/cake-autorate.primary.log` (in dependence upon the the instance identifier 'cake-autorate_config.identifier.sh` set in the config file name). 
-
-WARNING: Take care to ensure sufficient free memory exists in router to handle selected logging parameters.
-
-## Example output of 'ps |grep -e bash -e fping'
-
-cake-autorate employs multiple concurrent processes and uses inter process communication therebetween. 
+CAKE-autorate uses inter-process communication between
+multiple concurrent processes to dramatically decrease
+the CPU required to perform its many tasks.
+The `ps |grep -e bash -e fping` shows the many tasks running: 
 
 ```bash
 root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
@@ -249,19 +80,6 @@ root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
  2841 root      1928 S    fping --timestamp --loop --period 300 --interval 50 --timeout 10000 1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4 9.9.9.9 9
 ```
 
-## Preserving CAKE-autorate files for backup or upgrades
-
-The [Backup and Restore page on the wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
-describes how files can be saved across upgrades. 
-
-[Add these files on the **Configuration** tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up),
-so they will be saved in backups and preserved across snapshot upgrades.
-
- ```
-/root/cake-autorate
-/etc/init.d/cake-autorate
- ```
-  
 ## A Request to Testers
 
-If you use this script I have just one ask. Please post your experience on this [OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/). Your feedback will help improve the script for the benefit of others.  
+If you use this script, please post your experience on this [OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/). Your feedback will help improve the script for the benefit of others.  

--- a/README.md
+++ b/README.md
@@ -1,58 +1,105 @@
 # CAKE with Adaptive Bandwidth - "autorate"
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. This is intended for variable bandwidth connections such as LTE, Starlink, and cable modems and is not generally required for use on connections that have a stable, fixed bandwidth.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
+bandwidth settings based on traffic load and round-trip time measurements.
+This is intended for variable bandwidth connections such as
+LTE, Starlink, and cable modems and is not generally required
+for use on connections that have a stable, fixed bandwidth.
 
-[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/) is an algorithm that manages the buffering of data being sent/received by a device such as an [OpenWrt router](https://openwrt.org) so that no more data is queued than is necessary, minimizing the latency ("bufferbloat") and improving the responsiveness of a network.
+[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/)
+is an algorithm that manages the buffering of data being sent/received by a device
+such as an [OpenWrt router](https://openwrt.org)
+so that no more data is queued than is necessary, minimizing the latency ("bufferbloat")
+and improving the responsiveness of a network.
 
-Present version is 2.1.0 - please see [the changelog](CHANGELOG.md) for details. 
+Present version is 2.1.0 - please see [the changelog](CHANGELOG.md) for details.
 
 ## The Problem: CAKE on Variable Speed Connections forces an Unpalatable Compromise
 
-The CAKE algorithm works from fixed upload and download bandwidth settings to manage its queues. Variable bandwidth connections present a challenge because the actual bandwidth at any given moment is not known. 
+The CAKE algorithm works from fixed upload and download bandwidth
+settings to manage its queues.
+Variable bandwidth connections present a challenge because
+the actual bandwidth at any given moment is not known.
 
-Because CAKE works with fixed speed parameters the user must choose a compromise bandwidth setting. Setting it too low means lost bandwidth in exchange for latency control; setting the parameter too high induces bufferbloat when the link slows down.
+Because CAKE works with fixed speed parameters the user must choose
+a compromise bandwidth setting.
+Setting it too low means lost bandwidth in exchange for latency control;
+setting the parameter too high induces bufferbloat when the link slows down.
 
-This compromise is not ideal: when the usable line rate is above the set compromise bandwidth, the connection is unnecessarily throttled to the compromise setting resulting in lost bandwidth (yellow); when the usable line rate falls below the compromise value, the connection is not throttled enough (green) resulting in bufferbloat.
+This compromise is not ideal: when the usable line rate is above the
+set compromise bandwidth, the connection is unnecessarily throttled
+to the compromise setting resulting in lost bandwidth (yellow);
+when the usable line rate falls below the compromise value,
+the connection is not throttled enough (green) resulting in bufferbloat.
 
 <img src="images/bandwidth-compromise.png" width=75% height=75%>
 
 ## The Solution: Set CAKE parameters based on _Load_ and _RTT_
 
-The CAKE-autorate script continually measures the load and Round-Trip-Time (RTT) to adjust the upload and download settings for the CAKE algorithm.
+The CAKE-autorate script continually measures the load and
+Round-Trip-Time (RTT) to adjust the upload and download settings
+for the CAKE algorithm.
 
 ## Theory of Operation
 
-`cake-autorate.sh` monitors load (rx and tx utilization) and ping responses from one or more reflectors, and adjusts the download and upload bandwidth settings for CAKE. Rate control is intentionally kept as simple as possible and follows the following approach:
+`cake-autorate.sh` monitors load (rx and tx utilization) and ping responses
+from one or more reflectors, and adjusts the download and upload
+bandwidth settings for CAKE.
+Rate control is intentionally kept as simple as possible and follows
+the following approach:
 
-- with low load, decay rate back to the configured baseline (and subject to refractory period)
+- with low load, decay rate back to the configured baseline
+(and subject to refractory period)
 - with high load, increase rate subject to the configured maximum
-- on bufferbloat (when increased latency is detected), decrease rate subject to the configured min (and subject to refractory period)
+- on bufferbloat (when increased latency is detected), decrease rate subject
+to the configured min (and subject to refractory period)
 
 <img src="images/cake-bandwidth-autorate-rate-control.png" width=80% height=80%>
 
-**Setting the minimum bandwidth:** 
-Set the minimum value to the worst possible observed bufferbloat-free bandwidth. Ideally this CAKE bandwidth should never result in bufferbloat even under the worst conditions. This is a hard minimum - the script will never reduce the bandwidth below this level.
+**Setting the minimum bandwidth:**
+Set the minimum value to the worst possible observed bufferbloat-free bandwidth.
+Ideally this setting should never result in bufferbloat even under the worst conditions.
+This is a hard minimum - the script will never reduce the bandwidth below this level.
 
-**Setting the baseline bandwidth:** 
-This is the steady state bandwidth to be maintained under no or low load. This is likely the compromise bandwidth described above, i.e. the value you would set CAKE to that is bufferbloat free most, but not necessarily all, of the time. 
+**Setting the baseline bandwidth:**
+This is the steady state bandwidth to be maintained under no or low load.
+This is likely the compromise bandwidth described above, i.e.
+the value you would set CAKE to that is bufferbloat free most,
+but not necessarily all, of the time.
 
-**Setting the maximum bandwidth:** 
-The maximum bandwidth should be set to the lower of the maximum bandwidth that the ISP can provide or the maximum bandwidth required by the user. The script will adjust the bandwidth up when there is traffic, as long no RTT spike is detected. Setting this value to a maximum required level will have the advantage that the script will stay at that level during optimum conditions rather than always having to test whether the bandwidth can be increased (which necessarily results in allowing some excess latency through).
+**Setting the maximum bandwidth:**
+The maximum bandwidth should be set to the lower of the maximum bandwidth
+that the ISP can provide or the maximum bandwidth required by the user.
+The script will adjust the bandwidth up when there is traffic,
+as long no RTT spike is detected.
+Setting this value to a maximum required level will have the advantage that
+the script will stay at that level during optimum conditions rather than
+always having to test whether the bandwidth can be increased
+(which necessarily results in allowing some excess latency through).
 
-To elaborate on setting the minimum and maximum, a variable bandwidth connection may be most ideally divided up into a known fixed, stable component, on top of which is provided an unknown variable component:
+To elaborate on setting the minimum and maximum, a variable bandwidth connection
+may be most ideally divided up into a known fixed, stable component,
+on top of which is provided an unknown variable component:
 
 ![image of cake bandwidth adaptation](images/cake-bandwidth-adaptation.png)
 
-The minimum bandwidth is then set to (or slightly below) the fixed component, and the maximum bandwidth may be set to (or slightly above) the maximum observed bandwidth. Or, if a lower maximum bandwidth is required by the user, the maximum bandwidth is set to that lower bandwidth as explained above.
+The minimum bandwidth is then set to (or slightly below) the fixed component,
+and the maximum bandwidth may be set to (or slightly above)
+the maximum observed bandwidth.
+Or, if a lower maximum bandwidth is required by the user,
+the maximum bandwidth is set to that lower bandwidth as explained above.
 
-The baseline bandwidth is likely optimally either the minimum bandwidth or somewhere close thereto (e.g. the compromise bandwidth). 
+The baseline bandwidth is likely optimally either the minimum bandwidth
+or somewhere close thereto (e.g. the compromise bandwidth).
 
-There is a detailed and fun discussion with plenty of sketches relating to the development of the script and alternatives on the
+There is a detailed and fun discussion with plenty of sketches relating to the
+development of the script and alternatives on the
 [OpenWrt Forum - CAKE /w Adaptive Bandwidth.](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/312)
 
 ## Installation
 
-Read the installation instructions in the separate [INSTALLATION](./INSTALLATION.md) page.
+Read the installation instructions in the separate
+[INSTALLATION](./INSTALLATION.md) page.
 
 ## Analysis of the CAKE-autorate logs
 
@@ -64,7 +111,7 @@ Read about them in the [ANALYSIS](./ANALYSIS.md) page.
 CAKE-autorate uses inter-process communication between
 multiple concurrent processes to dramatically decrease
 the CPU required to perform its many tasks.
-The `ps |grep -e bash -e fping` shows the many tasks running: 
+The `ps |grep -e bash -e fping` shows the many tasks running:
 
 ```bash
 root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
@@ -82,4 +129,6 @@ root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
 
 ## A Request to Testers
 
-If you use this script, please post your experience on this [OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/). Your feedback will help improve the script for the benefit of others.  
+If you use this script, please post your experience on this
+[OpenWrt Forum thread](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/).
+Your feedback will help improve the script for the benefit of others.  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CAKE with Adaptive Bandwidth - "autorate"
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. CAKE-autorate is intended for variable bandwidth connections such as LTE, Starlink, and cable modems and is not generally required for use on connections that have a stable, fixed bandwidth.
+**CAKE-autorate** is a script that automatcially adjusts CAKE bandwidth settings based on traffic load and round-trip time measurements. CAKE-autorate is intended for variable bandwidth connections such as LTE, Starlink, and cable modems and is not generally required for use on connections that have a stable, fixed bandwidth.
 
 [CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/) is an algorithm that manages the buffering of data being sent/received by a device such as an [OpenWrt router](https://openwrt.org) so that no more data is queued than is necessary, minimizing the latency ("bufferbloat") and improving the responsiveness of a network.
 


### PR DESCRIPTION
With the impending release of a new version (after my test with an Archer c7), I decided to take a crack at the documentation.

I factored the main README into three files:
- README with introductory material
- INSTALLATION describing how to install on OpenWrt
- ANALYSIS discussing how to analyze log files

I also took the liberty of updating the CHANGELOG file to version 2.1, and reviewed the commit history to collected a few notes.

What's new in this PR:

- I made an editorial pass over all the files, using my best judgement to fix typos, and (hopefully) clarify descriptions
- I used `markdownlint` to check the Markdown file formats. This results in much shorter lines that will make subsequent edits more clear. It also fixes up some problems with the original Markdown markup.
- There's no mention of the _refractory period_ in the documents. I'm not sure I understand well enough to provide a description.
- In ANALYSIS, it would be good to provide a detailed description of the chart - there's a lot going on there.
- I wasn't quite sure where the "Optimization" discussion belongs (it's in the README for now)

Comments welcome. Thanks.