### PR TITLE
Format all markdown documents

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,12 +1,17 @@
 # Analyzing CAKE-autorate data
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. See the main [README](./README.md) page for more details of the algorithm.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
+bandwidth settings based on traffic load and round-trip time
+measurements. See the main [README](./README.md) page for more details
+of the algorithm.
 
 ## Exporting a Log File
 
-Extract a compressed log file from a running cake-autorate instance using one of these methods:
+Extract a compressed log file from a running cake-autorate instance
+using one of these methods:
 
-1. Run the auto-generated _log\_file\_export_ script inside the run directory:
+1. Run the auto-generated _log_file_export_ script inside the run
+   directory:
 
    ```bash
    /var/run/cake-autorate/*/log_file_export
@@ -14,19 +19,22 @@ Extract a compressed log file from a running cake-autorate instance using one of
 
    ... or ...
 
-2. Send a USR1 signal to the main log file process(es) using:
+1. Send a USR1 signal to the main log file process(es) using:
 
    ```bash
    awk -F= '/^maintain_log_file=/ {print $2}' /var/run/cake-autorate/*/proc_pids | xargs kill -USR1
    ```
 
-Either will place a compressed log file in _/var/log_ with the date and time in its filename.
+Either will place a compressed log file in _/var/log_ with the date
+and time in its filename.
 
 ## Resetting the Log File
 
-Force a log file reset on a running cake-autorate instance by using one of these methods:
+Force a log file reset on a running cake-autorate instance by using
+one of these methods:
 
-1. Run the auto-generated log_file_rotate script inside the run directory:
+1. Run the auto-generated log_file_rotate script inside the run
+   directory:
 
    ```bash
    /var/run/cake-autorate/*/log_file_reset
@@ -34,7 +42,7 @@ Force a log file reset on a running cake-autorate instance by using one of these
 
    ... or ...
 
-2. Send a USR2 signal to the main log file process(es) using:
+1. Send a USR2 signal to the main log file process(es) using:
 
    ```bash
    awk -F= '/^maintain_log_file=/ {print $2}' /var/run/cake-autorate/*/proc_pids | xargs kill -USR2
@@ -42,17 +50,22 @@ Force a log file reset on a running cake-autorate instance by using one of these
 
 ## Plotting the Log File
 
-The excellent Octave/Matlab program _fn\_parse\_autorate\_log.m_ by @moeller0 of OpenWrt can read an exported log file and produce a helpful graph like this:
+The excellent Octave/Matlab program _fn_parse_autorate_log.m_ by
+@moeller0 of OpenWrt can read an exported log file and produce a
+helpful graph like this:
 
 <img src="https://user-images.githubusercontent.com/10721999/194724668-d8973bb6-5a37-4b05-a212-3514db8f56f1.png" width=80% height=80%>
 
-The command below will run the Octave program (see the introductory notes in _fn\_parse\_autorate\_log.m_ for more details):
+The command below will run the Octave program (see the introductory
+notes in _fn_parse_autorate_log.m_ for more details):
 
 ```bash
 octave -qf --eval 'fn_parse_autorate_log("./log.gz", "./output.pdf")'
 ```
 
-The script below can be run on a remote machine to extract the log from the router and generate the pdfs for viewing from the remote machine:
+The script below can be run on a remote machine to extract the log
+from the router and generate the pdfs for viewing from the remote
+machine:
 
 ```bash
 log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,155 +1,271 @@
 # Changelog
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and one-way-delay or round-trip time measurements.
-Read the [README](./README.md) file for more about CAKE-autorate. This is the history of changes.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
+bandwidth settings based on traffic load and one-way-delay or
+round-trip time measurements. Read the [README](./README.md) file for
+more about CAKE-autorate. This is the history of changes.
 
 ## 2023-05-27 - Version 2.0
 
-- This version incorporates a restructure of the bash code for improved robustness, stability and performance.
-- CAKE-autorate has even lower CPU requirements and can now run successfully on older routers.
+- This version incorporates a restructure of the bash code for
+  improved robustness, stability and performance.
+- CAKE-autorate has even lower CPU requirements and can now run
+  successfully on older routers.
 - Many changes to catch and handle unusual error conditions
-- Introduce support for one way delays (OWDs) using the 'tsping' binary developed by @Lochnair of the OpenWrt forum. This works with ICMP type 13 (timestamp) requests to ascertain the delay in each direction (i.e. OWDs).
-- Employ FIFOs for passing not only data, but also commands, between the major processes, obviating costly reliance on temporary files. A side effect of this is that now /var/run/cake-autorate is mostly empty during runs.
+- Introduce support for one way delays (OWDs) using the 'tsping'
+  binary developed by @Lochnair of the OpenWrt forum. This works with
+  ICMP type 13 (timestamp) requests to ascertain the delay in each
+  direction (i.e. OWDs).
+- Employ FIFOs for passing not only data, but also commands, between
+  the major processes, obviating costly reliance on temporary files. A
+  side effect of this is that now /var/run/cake-autorate is mostly
+  empty during runs.
 - Significantly reduced CPU consumption.
 - Fixed eternal sleep issue.
-- Introduce more user-friendly config format by introducing cake-autorate_defaults.sh and cake-autorate_config.X.sh with the basics (interface names, whether to adjust the shaper rates and the min, base and max shaper rates) and any overrides from the default.
+- Introduce more user-friendly config format by introducing
+  cake-autorate_defaults.sh and cake-autorate_config.X.sh with the
+  basics (interface names, whether to adjust the shaper rates and the
+  min, base and max shaper rates) and any overrides from the default.
 - More intelligent check for another running instance.
-- Introduce more user-friendly log file exports by automatically generating an export script for each running cake-autorate instance inside /var/run/cake-autorate/*/.
+- Introduce more user-friendly log file exports by automatically
+  generating an export script for each running cake-autorate instance
+  inside /var/run/cake-autorate/\*/.
 - Many more fixes and improvements.
 - Particular thanks to @rany2 for his input on this version.
 
 ## 2022-12-13 - Version 1.2
 
-- cake-autorate now includes a sophisticated offline log file analysis utility written in Matlab/Octave: 'fn_parse_autorate_log.m' and maintained by @moeller0 (OpenWrt forum). This utility takes in a cake-autorate generated log file (in compressed or uncompressed format), which can be generated on the fly by sending an appropriate signal, and presents beautiful plots that depict latency and bandwidth over time together with many important cake-autorate vitals. This gratly simplifies assessing the efficacy of cake-autorate and associated settings on a given connection.
-- Multiple instances of cake-autorate is now supported. cake-autorate can now be run on multiple interfaces such as in the case of mwan3 failover. The interface is assigned by designating an appropaite interface identifier 'X' in the config file in the form cake-autorate_config.X.sh. A launcher script has been created that creates one cake-autorate instance per cake-autorate_config file placed inside /root/cake-autorate/. Log files are generated for each instance using the form /var/log/cake-autorate.X.log. The interface identifier 'X' cannot be empty.
-- Improved reflector management. With a relatively high frequency (default 1 minute) cake-autorate now compares reflector baselines and deltas and rotates out reflectors with either baselines that are excessively higher than the minimum or deltas that are too close to the trigger threshold. And with a relatively low frequency (default 60 minutes), cake-autorate now randomly rotates out a reflector from the presently active list. This simple algorithm is intended to converge upon a set of good reflectors from the intitial starting set. The initial starting set is now also randomized from the provided list of reflectors. The user is still encouraged to test the initial reflector list to rule out any particularly far away or highly variable reflectors.
-- Reflector stats may now optionally be printed to help monitor the efficacy of the reflector management and quality of the present reflectors.
-- LOAD stats may now optionally be printed to monitor achieved rates during sleep periods when pingers are shutdown.  
-- For each new sample, the baseline is now subtracted after having been updated rather than before having been updated.
-- Pinger prefix and arguments are now facilitated for the chosen pinger binary to help improve compatibility with mwan3.
-- Consideration was afforded to switching over to the use of SMA rather than EWMA for reflector baselines, but SMA was found to offer minimal improvement as compared to EWMA with appropriately chosen alpha values. The present use of EWMA with multiple alphas for increase and decrease enables tracking of either reflector owd minimums (conservative default) or averages (by setting alphas to around e.g. 0.095).
-- User can now specify own log path, e.g. in case of logging out to cloud mount using rclone or USB stick
+- cake-autorate now includes a sophisticated offline log file analysis
+  utility written in Matlab/Octave: 'fn_parse_autorate_log.m' and
+  maintained by @moeller0 (OpenWrt forum). This utility takes in a
+  cake-autorate generated log file (in compressed or uncompressed
+  format), which can be generated on the fly by sending an appropriate
+  signal, and presents beautiful plots that depict latency and
+  bandwidth over time together with many important cake-autorate
+  vitals. This gratly simplifies assessing the efficacy of
+  cake-autorate and associated settings on a given connection.
+- Multiple instances of cake-autorate is now supported. cake-autorate
+  can now be run on multiple interfaces such as in the case of mwan3
+  failover. The interface is assigned by designating an appropaite
+  interface identifier 'X' in the config file in the form
+  cake-autorate_config.X.sh. A launcher script has been created that
+  creates one cake-autorate instance per cake-autorate_config file
+  placed inside /root/cake-autorate/. Log files are generated for each
+  instance using the form /var/log/cake-autorate.X.log. The interface
+  identifier 'X' cannot be empty.
+- Improved reflector management. With a relatively high frequency
+  (default 1 minute) cake-autorate now compares reflector baselines
+  and deltas and rotates out reflectors with either baselines that are
+  excessively higher than the minimum or deltas that are too close to
+  the trigger threshold. And with a relatively low frequency (default
+  60 minutes), cake-autorate now randomly rotates out a reflector from
+  the presently active list. This simple algorithm is intended to
+  converge upon a set of good reflectors from the intitial starting
+  set. The initial starting set is now also randomized from the
+  provided list of reflectors. The user is still encouraged to test
+  the initial reflector list to rule out any particularly far away or
+  highly variable reflectors.
+- Reflector stats may now optionally be printed to help monitor the
+  efficacy of the reflector management and quality of the present
+  reflectors.
+- LOAD stats may now optionally be printed to monitor achieved rates
+  during sleep periods when pingers are shutdown.
+- For each new sample, the baseline is now subtracted after having
+  been updated rather than before having been updated.
+- Pinger prefix and arguments are now facilitated for the chosen
+  pinger binary to help improve compatibility with mwan3.
+- Consideration was afforded to switching over to the use of SMA
+  rather than EWMA for reflector baselines, but SMA was found to offer
+  minimal improvement as compared to EWMA with appropriately chosen
+  alpha values. The present use of EWMA with multiple alphas for
+  increase and decrease enables tracking of either reflector owd
+  minimums (conservative default) or averages (by setting alphas to
+  around e.g. 0.095).
+- User can now specify own log path, e.g. in case of logging out to
+  cloud mount using rclone or USB stick
 
 ## 2022-09-28 - Version 1.1
 
 Implemented several new features such as:
 
-- Switch default pinger binary to fping - it was identified that using concurrent instances of iputils-ping resulted in drift between ICMP requests, and fping solves this because it offers round robin pinging to multiple reflectors with tightly controlled timing between requests
-- Generalised pinger functions to support wrappers for different ping binaries - fping and iputils-ping now specifically supported and handled, and new ping binaries can easily be added by including appropriate wrapper functions.
-- Generalised code to work with one way delays (OWDs) from RTTs in preparation to use ICMP type 13 requests
-- Only use capacity estimate on bufferbloat detection where the adjusted shaper rate based thereon would exceed the minimum configured shaper rate (avoiding the situation where e.g. idle load on download during upload-related bufferbloat would cause download shaper rate to get punished all the way down to the minimum)
+- Switch default pinger binary to fping - it was identified that using
+  concurrent instances of iputils-ping resulted in drift between ICMP
+  requests, and fping solves this because it offers round robin
+  pinging to multiple reflectors with tightly controlled timing
+  between requests
+- Generalised pinger functions to support wrappers for different ping
+  binaries - fping and iputils-ping now specifically supported and
+  handled, and new ping binaries can easily be added by including
+  appropriate wrapper functions.
+- Generalised code to work with one way delays (OWDs) from RTTs in
+  preparation to use ICMP type 13 requests
+- Only use capacity estimate on bufferbloat detection where the
+  adjusted shaper rate based thereon would exceed the minimum
+  configured shaper rate (avoiding the situation where e.g. idle load
+  on download during upload-related bufferbloat would cause download
+  shaper rate to get punished all the way down to the minimum)
 - Stall detection and handling
-- Much better log file handling including defaulting to logging, supporting logging even when running from console, log file rotation on configured time elapsed or configured bytes written to
+- Much better log file handling including defaulting to logging,
+  supporting logging even when running from console, log file rotation
+  on configured time elapsed or configured bytes written to
 
 ## 2022-08-21 - Version 1.0
 
-- New installer script - cake-autorate-setup.sh - now installs all required files
-- Installer checks for presence of previous config and asks whether to overwrite
-- Installer also copies the service script into `/etc/init.d/cake-autorate`
-- Installer does NOT start the software, but displays instructions for config and starting
-- At startup, display version number and interface name and configured speeds
+- New installer script - cake-autorate-setup.sh - now installs all
+  required files
+- Installer checks for presence of previous config and asks whether to
+  overwrite
+- Installer also copies the service script into
+  `/etc/init.d/cake-autorate`
+- Installer does NOT start the software, but displays instructions for
+  config and starting
+- At startup, display version number and interface name and configured
+  speeds
 - Abort if the configured interfaces do not exist
 - Style guide: the name of the algorithm and repo is "CAKE-autorate"
 - All "cake-autorate..." filenames are lower case
-- New log_msg() function that places a simple time stamp on the each line
+- New log_msg() function that places a simple time stamp on the each
+  line
 - Moved images to their own directory
 - No other new/interesting functionality
 
 ## 2022-07-01
 
-- Significant testing with a Starlink connection (thanks to @gba of OpenWrt)
-- Have added code to compensate for Starlink satelite switch times to preemptively reduce shaper rates prior to switch thereby to help prevent or at least reduce the otherwise large RTT spikes associate with the switching
+- Significant testing with a Starlink connection (thanks to @gba of
+  OpenWrt)
+- Have added code to compensate for Starlink satelite switch times to
+  preemptively reduce shaper rates prior to switch thereby to help
+  prevent or at least reduce the otherwise large RTT spikes associate
+  with the switching
 
 ## 2022-06-07
 
 - Add optional startup delay
 - Fix octal/base issue on calculation of loads by forcing base 10
-- Prevent crash on interface reset in which rx/tx_bytes counters are reset by checking for negative achieved rates and setting to zero
-- Verify interfaces are up on startup and on main loop exit (and wait as necessary for them to come up)
+- Prevent crash on interface reset in which rx/tx_bytes counters are
+  reset by checking for negative achieved rates and setting to zero
+- Verify interfaces are up on startup and on main loop exit (and wait
+  as necessary for them to come up)
 
 ## 2022-06-02
 
-- No further changes - author now runs this code 24/7 as a service and it seems to **just work**
+- No further changes - author now runs this code 24/7 as a service and
+  it seems to **just work**
 
 ## 2022-04-25
 
-- Included reflector health monitoring and support for reflector rotation upon detection of bad reflectors
-- **Overall the code now seems to work very well and seems to have reached a mature stage**
+- Included reflector health monitoring and support for reflector
+  rotation upon detection of bad reflectors
+- **Overall the code now seems to work very well and seems to have
+  reached a mature stage**
 
 ## 2022-04-19
 
 - Many further optimizations to reduce CPU use and improve performance
-- Replaced coreutils-sleep with 'read -t' on dummy fifo to use bash inbuilt
+- Replaced coreutils-sleep with 'read -t' on dummy fifo to use bash
+  inbuilt
 - Added various features to help with weaker LTE connections
 - Implemented significant number of robustifications
 
 ## 2022-03-21
 
-- Huge reworking of CAKE-autorate. Now individual processes ping a reflector, maintain a baseline, and write out result lines to a common FIFO that is read in by a main loop and processed. Several optimisations have been effected to reduce CPU load. Sleep functionality has been added to put the pinging processes to sleep when the connection is not being used and to wake back up when the connection is used again - this saves unecessary CPU cycles and issuing pings throughout the 'wee' hours of the night.
-- This script seems to be working very well on the author's LTE conneciton. The author personally uses it as a service 24/7 now.
+- Huge reworking of CAKE-autorate. Now individual processes ping a
+  reflector, maintain a baseline, and write out result lines to a
+  common FIFO that is read in by a main loop and processed. Several
+  optimisations have been effected to reduce CPU load. Sleep
+  functionality has been added to put the pinging processes to sleep
+  when the connection is not being used and to wake back up when the
+  connection is used again - this saves unecessary CPU cycles and
+  issuing pings throughout the 'wee' hours of the night.
+- This script seems to be working very well on the author's LTE
+  conneciton. The author personally uses it as a service 24/7 now.
 
 ## 2022-02-18
 
 - Altered CAKE-autorate to employ inotifywait for main loop ticks
-- Now main loops ticks are triggered either by a delay event or tick trigger (whichever comes first)
+- Now main loops ticks are triggered either by a delay event or tick
+  trigger (whichever comes first)
 
 ## 2022-02-17
 
-- Completed and uploaded to new CAKE-autorate branch completely new bash implementation
+- Completed and uploaded to new CAKE-autorate branch completely new
+  bash implementation
 - This will likely be the future for this project
 
 ## 2022-02-04
 
-- Created new experimental-rapid-tick branch in which pings are made asynchronous with the main loop offering significantly more rapid ticks
-- Corrected main and both experimental branches to work with min RTT output from each ping call (not average)
+- Created new experimental-rapid-tick branch in which pings are made
+  asynchronous with the main loop offering significantly more rapid
+  ticks
+- Corrected main and both experimental branches to work with min RTT
+  output from each ping call (not average)
 
 ## 2021-12-11
 
-- Modified tick duration to 1s and timeout duration to 0.8 seconds in 'owd' code
+- Modified tick duration to 1s and timeout duration to 0.8 seconds in
+  'owd' code
 - This seems to give an owd routine that mostly works
-- Tested how 'owd' codes under independent upload and ownload saturations and it seems to work well
+- Tested how 'owd' codes under independent upload and ownload
+  saturations and it seems to work well
 - Much optimisation still needed
 
 ## 2021-12-10
 
 - Extensive development of 'owd' code
-- Noticed tick duration 0.5s would result in slowdown during heavy usage owing to hping3 1s timeout
-- Implemented timeout functionality to kill hping3 calls that take longer than 0.X seconds
+- Noticed tick duration 0.5s would result in slowdown during heavy
+  usage owing to hping3 1s timeout
+- Implemented timeout functionality to kill hping3 calls that take
+  longer than 0.X seconds
 - @Failsafe's awk parser a total joy to use!
 
 ## 2021-12-9
 
-- Based on discussion in OpenWrt CAKE /w Adaptive Bandwidth thread created new 'owd' branch
-- Adapted code to employ timestamp ICMP type 13 requests to try to ascertain direction of bufferbloat
-- On OpenWrt CAKE /w Adaptive Bandwidth thread much testing/discussion around various ping utilities
+- Based on discussion in OpenWrt CAKE /w Adaptive Bandwidth thread
+  created new 'owd' branch
+- Adapted code to employ timestamp ICMP type 13 requests to try to
+  ascertain direction of bufferbloat
+- On OpenWrt CAKE /w Adaptive Bandwidth thread much testing/discussion
+  around various ping utilities
 - nping found to support ICMP type 13 but slow and unreliable
-- settled on hping3 as identified by @Locknair (OpenWrt forum) as ery efficient and timing information proves reliable
-- @Failsafe (OpenWrt forum) demonstrated awk mastery by writing awk parser to handle output of hping3
+- settled on hping3 as identified by @Locknair (OpenWrt forum) as ery
+  efficient and timing information proves reliable
+- @Failsafe (OpenWrt forum) demonstrated awk mastery by writing awk
+  parser to handle output of hping3
 
 ## 2021-12-6
 
-- Reverted to old behaviour of decrementing both downlink and uplink rates upon bufferbloat detection
-- Whilst guestimating direction of bufferbloat based on load is a nice idea/hack, it proved dangerous and unreliable
-- Namely, suppose downlink load is 0.8 and uplink load is 0.4 and it is uplink that causes bufferbloat
-- In this situation, decrementing downlink rate (because this is the heavily loaded direction) does not solve
-- The bufferbloat, and this could result in downlink bandwidth being punished down to zero
+- Reverted to old behaviour of decrementing both downlink and uplink
+  rates upon bufferbloat detection
+- Whilst guestimating direction of bufferbloat based on load is a nice
+  idea/hack, it proved dangerous and unreliable
+- Namely, suppose downlink load is 0.8 and uplink load is 0.4 and it
+  is uplink that causes bufferbloat
+- In this situation, decrementing downlink rate (because this is the
+  heavily loaded direction) does not solve
+- The bufferbloat, and this could result in downlink bandwidth being
+  punished down to zero
 
 ## 2021-12-4
 
-- @richb-hanover encourages use of single rate rather than min/max rates to help simplify things
-- 'experimental' branch created that takes single uplink and downlink rates and adjusts rates based on those
+- @richb-hanover encourages use of single rate rather than min/max
+  rates to help simplify things
+- 'experimental' branch created that takes single uplink and downlink
+  rates and adjusts rates based on those
 - Seems to work but needs optimisation
-- Tried out idea in 'experimental' branch of decrementing only direction that is heavily loaded upon detection of bufferbloat
+- Tried out idea in 'experimental' branch of decrementing only
+  direction that is heavily loaded upon detection of bufferbloat
 - It mostly works, but edge cases may break it
 
 ## 2021-11-30 and early December
 
-- @richb-hanover encourages use of documentation and helps with creation of readme.
+- @richb-hanover encourages use of documentation and helps with
+  creation of readme.
 - Readme developed to help users
 
 ## 2021-11-23
 
-- Mysterious individual @dim-geo helpfuly replaces bc calls with awk calls
+- Mysterious individual @dim-geo helpfuly replaces bc calls with awk
+  calls
 - And also simplifies awk calls
 
 ## 2021-late October to early Novermver
@@ -161,11 +277,17 @@ Implemented several new features such as:
 
 - sqm-autorate is born!
 - A brief history:
-- @Lynx (OpenWrt forum) wondered about simple algorith along the lines:
-- if load < 50% of minimum set load then assume no load and update moving average of unloaded ping to 8.8.8.8
-if load > 50% of minimum set load acquire set of sample points by pinging 8.8.8.8 and acquire sample mean
-measure bufferbloat by subtracting moving average of unloaded ping from sample mean
-ascertain load during sample acquisition and make bandwidth increase or decrease decision based on determined load and determination of bufferbloat or not
-- And @Lynx asked SQM/CAKE expert @moeller0 (OpenWrt forum) to suggest a basic algorithm.
-- @moeller0 suggested the following approach: <https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/88?u=lynx>
+- @Lynx (OpenWrt forum) wondered about simple algorith along the
+  lines:
+- if load \< 50% of minimum set load then assume no load and update
+  moving average of unloaded ping to 8.8.8.8 if load > 50% of minimum
+  set load acquire set of sample points by pinging 8.8.8.8 and acquire
+  sample mean measure bufferbloat by subtracting moving average of
+  unloaded ping from sample mean ascertain load during sample
+  acquisition and make bandwidth increase or decrease decision based
+  on determined load and determination of bufferbloat or not
+- And @Lynx asked SQM/CAKE expert @moeller0 (OpenWrt forum) to suggest
+  a basic algorithm.
+- @moeller0 suggested the following approach:
+  <https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/88?u=lynx>
 - @Lynx wrote a shell script to implement this routine

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,118 +1,156 @@
 # Installing CAKE-autorate on OpenWrt
 
-**CAKE-autorate** is a script that minimizes latency by adjusting CAKE bandwidth settings based on traffic load and round-trip time measurements. See the main [README](./README.md) page for more details of the algorithm.
+**CAKE-autorate** is a script that minimizes latency by adjusting CAKE
+bandwidth settings based on traffic load and round-trip time
+measurements. See the main [README](./README.md) page for more details
+of the algorithm.
 
 ## Installation Steps
 
-CAKE-autorate provides an installation script that installs all the required tools. To use it:
+CAKE-autorate provides an installation script that installs all the
+required tools. To use it:
 
-- Install SQM (`luci-app-sqm`) and enable and configure `cake` Queue Discipline on the interface(s) as described in the [OpenWrt SQM documentation](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
-- Alternatively, and especially if you may have more complex networking needs:
-   - DSCPs - consider [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple);
-   - WireGuard with PBR - consider [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
+- Install SQM (`luci-app-sqm`) and enable and configure `cake` Queue
+  Discipline on the interface(s) as described in the
+  [OpenWrt SQM documentation](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
+
+- Alternatively, and especially if you may have more complex
+  networking needs:
+
+  - DSCPs - consider
+    [cake-simple-qos](https://github.com/lynxthecat/cake-qos-simple);
+  - WireGuard with PBR - consider
+    [cake-dual-ifb](https://github.com/lynxthecat/cake-dual-ifb).
+
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
-- Use the installer script by copying and pasting each of the commands below.
-The commands retrieve the current version from this repo:
 
-   ```bash
-   wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/CAKE-autorate/master/setup.sh
-   
-   sh /tmp/cake-autorate_setup.sh
-   ```
+- Use the installer script by copying and pasting each of the commands
+  below. The commands retrieve the current version from this repo:
 
-- The installer script will detect a previous configuration file, and ask whether to preserve it. 
+  ```bash
+  wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/CAKE-autorate/master/setup.sh
+
+  sh /tmp/cake-autorate_setup.sh
+  ```
+
+- The installer script will detect a previous configuration file, and
+  ask whether to preserve it.
+
 - For a fresh install, you will need to undertake the following steps.
-- Edit the _config.primary.sh_ script (in the _/root/cake-autorate_ directory) using vi or nano to set the configuration parameters below (see comments in _config.primary.sh_ for details).
 
-  - Change `dl_if` and `ul_if` to match the names of the upload and download interfaces to which CAKE is applied. These can be obtained, for example, by consulting the
-  configured SQM settings in LuCI or by examining the output of `tc qdisc ls`.
+- Edit the _config.primary.sh_ script (in the _/root/cake-autorate_
+  directory) using vi or nano to set the configuration parameters
+  below (see comments in _config.primary.sh_ for details).
 
-      | Variable | Setting |
-      |----: |   :-------- |
-      | `dl_if` | Interface that downloads data (often _ifb4-wan_)
-      | `ul_if` | Interface that uploads (often _wan_) |
+  - Change `dl_if` and `ul_if` to match the names of the upload and
+    download interfaces to which CAKE is applied. These can be
+    obtained, for example, by consulting the configured SQM settings
+    in LuCI or by examining the output of `tc qdisc ls`.
+
+    | Variable | Setting                                          |
+    | -------: | :----------------------------------------------- |
+    |  `dl_if` | Interface that downloads data (often _ifb4-wan_) |
+    |  `ul_if` | Interface that uploads (often _wan_)             |
 
   - Set bandwidth variables as described in _config.primary.sh_.
 
-      | Type | Download | Upload |
-      |----: |   :-------- | :------ |
-      | Min. | `min_dl_shaper_rate_kbps` | `min_ul_shaper_rate_kbps` |
-      | Base | `base_dl_shaper_rate_kbps` | `base_ul_shaper_rate_kbps` |
-      | Max. | `max_dl_shaper_rate_kbps` | `max_ul_shaper_rate_kbps` |
+    | Type | Download                   | Upload                     |
+    | ---: | :------------------------- | :------------------------- |
+    | Min. | `min_dl_shaper_rate_kbps`  | `min_ul_shaper_rate_kbps`  |
+    | Base | `base_dl_shaper_rate_kbps` | `base_ul_shaper_rate_kbps` |
+    | Max. | `max_dl_shaper_rate_kbps`  | `max_ul_shaper_rate_kbps`  |
 
-   - Choose whether cake-autorate should adjust the shaper rates (disable for monitoring only):
-  
-      | Variable | Setting |
-      |----: |   :-------- |
-      | `adjust_dl_shaper_rate` | enable (1) or disable (0) download shaping |
-      | `adjust_ul_shaper_rate` | enable (1) or disable (0) upload shaping |
+  - Choose whether cake-autorate should adjust the shaper rates
+    (disable for monitoring only):
 
-- The other configuration file - _defaults.sh_ - has sensible default settings. After CAKE-autorate has been installed and is running, you may wish to change some of these.
-  
-  - For example, to set a different `dl_delay_thr_ms`, then add a line to the config like:
-  
-     ```bash
-     dl_delay_thr_ms=100
-     ```
-  
+    |                Variable | Setting                                    |
+    | ----------------------: | :----------------------------------------- |
+    | `adjust_dl_shaper_rate` | enable (1) or disable (0) download shaping |
+    | `adjust_ul_shaper_rate` | enable (1) or disable (0) upload shaping   |
+
+- The other configuration file - _defaults.sh_ - has sensible default
+  settings. After CAKE-autorate has been installed and is running, you
+  may wish to change some of these.
+
+  - For example, to set a different `dl_delay_thr_ms`, then add a line
+    to the config like:
+
+    ```bash
+    dl_delay_thr_ms=100
+    ```
+
   - The following variables control logging:
 
-      | Variable | Setting |
-      |----: |   :-------- |
-      | `output_processing_stats` | If non-zero, log the results of every iteration through the process |
-      | `output_cake_changes` | If non-zero, log when changes are made to CAKE settings via `tc` - this shows when CAKE-autorate is adjusting the shaper |
-      | `debug` | If non-zero, debug lines will be output |
-      | `log_to_file` | If non-zero, log lines will be sent to /tmp/cake-autorate.log regardless of whether printing to console and after every write the log file will be rotated f either `log_file_max_time_mins` have elapsed or `log_file_max_size_KB` has been exceeded |
-      | `log_file_max_time_mins` | Number of minutes to elapse between log file rotaton |
-      | `log_file_max_size_KB` | Number of KB (i.e. bytes/1024) worth of log lines between log file rotations |
+    |                  Variable | Setting                                                                                                                                                                                                                                               |
+    | ------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+    | `output_processing_stats` | If non-zero, log the results of every iteration through the process                                                                                                                                                                                   |
+    |     `output_cake_changes` | If non-zero, log when changes are made to CAKE settings via `tc` - this shows when CAKE-autorate is adjusting the shaper                                                                                                                              |
+    |                   `debug` | If non-zero, debug lines will be output                                                                                                                                                                                                               |
+    |             `log_to_file` | If non-zero, log lines will be sent to /tmp/cake-autorate.log regardless of whether printing to console and after every write the log file will be rotated f either `log_file_max_time_mins` have elapsed or `log_file_max_size_KB` has been exceeded |
+    |  `log_file_max_time_mins` | Number of minutes to elapse between log file rotaton                                                                                                                                                                                                  |
+    |    `log_file_max_size_KB` | Number of KB (i.e. bytes/1024) worth of log lines between log file rotations                                                                                                                                                                          |
 
 ## Manual testing
 
-To start the `cake-autorate.sh` script and watch the logged output as it adjusts the CAKE parameters, run these commands:
+To start the `cake-autorate.sh` script and watch the logged output as
+it adjusts the CAKE parameters, run these commands:
 
-   ```bash
-   cd /root/cake-autorate     # to the cake-autorate directory
-   ./cake-autorate.sh
-   ```
+```bash
+cd /root/cake-autorate     # to the cake-autorate directory
+./cake-autorate.sh
+```
 
-- Monitor the script output to see how it adjusts the download and upload rates as you use the connection.
+- Monitor the script output to see how it adjusts the download and
+  upload rates as you use the connection.
 - Press ^C to halt the process.
 
 ## Install as a service
 
-You can install CAKE-autorate as a service that starts up the autorate process whenever the router reboots. To do this:
+You can install CAKE-autorate as a service that starts up the autorate
+process whenever the router reboots. To do this:
 
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
+
 - Run these commands to enable and start the service file:
 
-   ```bash
-   # the setup.sh script already installed the service file
-   service cake-autorate enable
-   service cake-autorate start
-   ```
+  ```bash
+  # the setup.sh script already installed the service file
+  service cake-autorate enable
+  service cake-autorate start
+  ```
 
-If you edit any of the configuration files, you will need to restart the service with `service cake-autorate restart`
+If you edit any of the configuration files, you will need to restart
+the service with `service cake-autorate restart`
 
-When running as a service, the `cake-autorate.sh` script outputs to _/var/log/cake-autorate.primary.log_ (observing the instance identifier _cake-autorate\_config.identifier.sh_ set in the config file name).
+When running as a service, the `cake-autorate.sh` script outputs to
+_/var/log/cake-autorate.primary.log_ (observing the instance
+identifier _cake-autorate_config.identifier.sh_ set in the config file
+name).
 
-WARNING: Take care to ensure sufficient free (Flash) memory exists in router to handle selected logging parameters.
+WARNING: Take care to ensure sufficient free (Flash) memory exists in
+router to handle selected logging parameters.
 
 ## Preserving CAKE-autorate files for backup or upgrades
 
-OpenWrt devices can save files across upgrades. Read the [Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
+OpenWrt devices can save files across upgrades. Read the
+[Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)
 for details.
 
-To ensure the CAKE-autorate script and configuration files are preserved, enter the files below to the OpenWrt router's [Configuration tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up)
+To ensure the CAKE-autorate script and configuration files are
+preserved, enter the files below to the OpenWrt router's
+[Configuration tab](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#back_up)
 
- ```bash
+```bash
 /root/cake-autorate
 /etc/init.d/cake-autorate
- ```
-  
+```
+
 ## Multi-WAN Setups
 
-- CAKE-autorate has been designed to run multiple instances simultaneously.
-- cake-autorate will run one instance per config file present in the _/root/cake-autorate/_ directory in the form:
+- CAKE-autorate has been designed to run multiple instances
+  simultaneously.
+- cake-autorate will run one instance per config file present in the
+  _/root/cake-autorate/_ directory in the form:
 
 ```bash
 config.interface.sh
@@ -122,19 +160,31 @@ where 'interface' is replaced with e.g. 'primary', 'secondary', etc.
 
 ## Example Starlink Configuration
 
-- OpenWrt forum member @gba has kindly shared [his Starlink config](Example_Starlink_config.sh).
-This ought to provide some helpful pointers for adding appropriate overrides for Starlink users.
+- OpenWrt forum member @gba has kindly shared
+  [his Starlink config](Example_Starlink_config.sh). This ought to
+  provide some helpful pointers for adding appropriate overrides for
+  Starlink users.
 - See discussion on OpenWrt thread from
-[around this post](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/3100?u=lynx).
+  [around this post](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/108848/3100?u=lynx).
 
 ## Selecting a "ping binary"
 
-CAKE-autorate reads the `$pinger_binary` variable in the config file to select the ping binary. Choices include:
+CAKE-autorate reads the `$pinger_binary` variable in the config file
+to select the ping binary. Choices include:
 
-- **fping** (DEFAULT) round robin pinging to multiple reflectors with tightly controlled timings
-- **tsping** round robin ICMP type 13 pinging to multiple reflectors with tightly controlled timings
-- **iputils-ping** more advanced pinging than the default busybox ping with sub 1s ping frequency
+- **fping** (DEFAULT) round robin pinging to multiple reflectors with
+  tightly controlled timings
+- **tsping** round robin ICMP type 13 pinging to multiple reflectors
+  with tightly controlled timings
+- **iputils-ping** more advanced pinging than the default busybox ping
+  with sub 1s ping frequency
 
-**About tsping** @Lochnair has coded up an elegant ping utility in C that sends out ICMP type 13 requests in a round robin manner, thereby facilitating determination of one way delays (OWDs), i.e. not just round trip time (RTT), but the constituent download and upload delays, relative to multiple reflectors. Presently this must be compiled manually (although we can expect an official OpenWrt package soon).
+**About tsping** @Lochnair has coded up an elegant ping utility in C
+that sends out ICMP type 13 requests in a round robin manner, thereby
+facilitating determination of one way delays (OWDs), i.e. not just
+round trip time (RTT), but the constituent download and upload delays,
+relative to multiple reflectors. Presently this must be compiled
+manually (although we can expect an official OpenWrt package soon).
 
-Instructions for building a `tsping` OpenWrt package are available [from github.](https://github.com/Lochnair/tsping)
+Instructions for building a `tsping` OpenWrt package are available
+[from github.](https://github.com/Lochnair/tsping)

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,27 +1,28 @@
-GNU General Public License
-==========================
+# GNU General Public License
 
-_Version 2, June 1991_  
-_Copyright © 1989, 1991 Free Software Foundation, Inc.,_  
-_51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA_
+_Version 2, June 1991_\
+_Copyright © 1989, 1991 Free Software
+Foundation, Inc.,_\
+_51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA_
 
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
 
 ### Preamble
 
-The licenses for most software are designed to take away your
-freedom to share and change it.  By contrast, the GNU General Public
-License is intended to guarantee your freedom to share and change free
-software--to make sure the software is free for all its users.  This
+The licenses for most software are designed to take away your freedom
+to share and change it. By contrast, the GNU General Public License is
+intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users. This
 General Public License applies to most of the Free Software
 Foundation's software and to any other program whose authors commit to
-using it.  (Some other Free Software Foundation software is covered by
-the GNU Lesser General Public License instead.)  You can apply it to
+using it. (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.) You can apply it to
 your programs, too.
 
 When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
+price. Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 this service if you wish), that you receive source code or can get it
 if you want it, that you can change the software or use pieces of it
@@ -29,53 +30,55 @@ in new free programs; and that you know you can do these things.
 
 To protect your rights, we need to make restrictions that forbid
 anyone to deny you these rights or to ask you to surrender the rights.
-These restrictions translate to certain responsibilities for you if you
-distribute copies of the software, or if you modify it.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the software, or if you modify it.
 
 For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must give the recipients all the rights that
-you have.  You must make sure that they, too, receive or can get the
-source code.  And you must show them these terms so they know their
+you have. You must make sure that they, too, receive or can get the
+source code. And you must show them these terms so they know their
 rights.
 
-We protect your rights with two steps: **(1)** copyright the software, and
-**(2)** offer you this license which gives you legal permission to copy,
-distribute and/or modify the software.
+We protect your rights with two steps: **(1)** copyright the software,
+and **(2)** offer you this license which gives you legal permission to
+copy, distribute and/or modify the software.
 
 Also, for each author's protection and ours, we want to make certain
 that everyone understands that there is no warranty for this free
-software.  If the software is modified by someone else and passed on, we
-want its recipients to know that what they have is not the original, so
-that any problems introduced by others will not reflect on the original
-authors' reputations.
+software. If the software is modified by someone else and passed on,
+we want its recipients to know that what they have is not the
+original, so that any problems introduced by others will not reflect
+on the original authors' reputations.
 
 Finally, any free program is threatened constantly by software
-patents.  We wish to avoid the danger that redistributors of a free
+patents. We wish to avoid the danger that redistributors of a free
 program will individually obtain patent licenses, in effect making the
-program proprietary.  To prevent this, we have made it clear that any
-patent must be licensed for everyone's free use or not licensed at all.
+program proprietary. To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at
+all.
 
 The precise terms and conditions for copying, distribution and
 modification follow.
 
 ### TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-**0.** This License applies to any program or other work which contains
-a notice placed by the copyright holder saying it may be distributed
-under the terms of this General Public License.  The “Program”, below,
-refers to any such program or work, and a “work based on the Program”
-means either the Program or any derivative work under copyright law:
-that is to say, a work containing the Program or a portion of it,
-either verbatim or with modifications and/or translated into another
-language.  (Hereinafter, translation is included without limitation in
-the term “modification”.)  Each licensee is addressed as “you”.
+**0.** This License applies to any program or other work which
+contains a notice placed by the copyright holder saying it may be
+distributed under the terms of this General Public License. The
+“Program”, below, refers to any such program or work, and a “work
+based on the Program” means either the Program or any derivative work
+under copyright law: that is to say, a work containing the Program or
+a portion of it, either verbatim or with modifications and/or
+translated into another language. (Hereinafter, translation is
+included without limitation in the term “modification”.) Each licensee
+is addressed as “you”.
 
 Activities other than copying, distribution and modification are not
-covered by this License; they are outside its scope.  The act of
+covered by this License; they are outside its scope. The act of
 running the Program is not restricted, and the output from the Program
-is covered only if its contents constitute a work based on the
-Program (independent of having been made by running the Program).
-Whether that is true depends on what the Program does.
+is covered only if its contents constitute a work based on the Program
+(independent of having been made by running the Program). Whether that
+is true depends on what the Program does.
 
 **1.** You may copy and distribute verbatim copies of the Program's
 source code as you receive it, in any medium, provided that you
@@ -86,39 +89,41 @@ and give any other recipients of the Program a copy of this License
 along with the Program.
 
 You may charge a fee for the physical act of transferring a copy, and
-you may at your option offer warranty protection in exchange for a fee.
+you may at your option offer warranty protection in exchange for a
+fee.
 
-**2.** You may modify your copy or copies of the Program or any portion
-of it, thus forming a work based on the Program, and copy and
+**2.** You may modify your copy or copies of the Program or any
+portion of it, thus forming a work based on the Program, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
 
-* **a)** You must cause the modified files to carry prominent notices
-stating that you changed the files and the date of any change.
-* **b)** You must cause any work that you distribute or publish, that in
-whole or in part contains or is derived from the Program or any
-part thereof, to be licensed as a whole at no charge to all third
-parties under the terms of this License.
-* **c)** If the modified program normally reads commands interactively
-when run, you must cause it, when started running for such
-interactive use in the most ordinary way, to print or display an
-announcement including an appropriate copyright notice and a
-notice that there is no warranty (or else, saying that you provide
-a warranty) and that users may redistribute the program under
-these conditions, and telling the user how to view a copy of this
-License.  (Exception: if the Program itself is interactive but
-does not normally print such an announcement, your work based on
-the Program is not required to print an announcement.)
+- **a)** You must cause the modified files to carry prominent notices
+  stating that you changed the files and the date of any change.
+- **b)** You must cause any work that you distribute or publish, that
+  in whole or in part contains or is derived from the Program or any
+  part thereof, to be licensed as a whole at no charge to all third
+  parties under the terms of this License.
+- **c)** If the modified program normally reads commands interactively
+  when run, you must cause it, when started running for such
+  interactive use in the most ordinary way, to print or display an
+  announcement including an appropriate copyright notice and a notice
+  that there is no warranty (or else, saying that you provide a
+  warranty) and that users may redistribute the program under these
+  conditions, and telling the user how to view a copy of this License.
+  (Exception: if the Program itself is interactive but does not
+  normally print such an announcement, your work based on the Program
+  is not required to print an announcement.)
 
-These requirements apply to the modified work as a whole.  If
+These requirements apply to the modified work as a whole. If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
 themselves, then this License, and its terms, do not apply to those
-sections when you distribute them as separate works.  But when you
+sections when you distribute them as separate works. But when you
 distribute the same sections as part of a whole which is a work based
 on the Program, the distribution of the whole must be on the terms of
 this License, whose permissions for other licensees extend to the
-entire whole, and thus to each and every part regardless of who wrote it.
+entire whole, and thus to each and every part regardless of who wrote
+it.
 
 Thus, it is not the intent of this section to claim rights or contest
 your rights to work written entirely by you; rather, the intent is to
@@ -134,26 +139,27 @@ the scope of this License.
 under Section 2) in object code or executable form under the terms of
 Sections 1 and 2 above provided that you also do one of the following:
 
-* **a)** Accompany it with the complete corresponding machine-readable
-source code, which must be distributed under the terms of Sections
-1 and 2 above on a medium customarily used for software interchange; or,
-* **b)** Accompany it with a written offer, valid for at least three
-years, to give any third party, for a charge no more than your
-cost of physically performing source distribution, a complete
-machine-readable copy of the corresponding source code, to be
-distributed under the terms of Sections 1 and 2 above on a medium
-customarily used for software interchange; or,
-* **c)** Accompany it with the information you received as to the offer
-to distribute corresponding source code.  (This alternative is
-allowed only for noncommercial distribution and only if you
-received the program in object code or executable form with such
-an offer, in accord with Subsection b above.)
+- **a)** Accompany it with the complete corresponding machine-readable
+  source code, which must be distributed under the terms of Sections 1
+  and 2 above on a medium customarily used for software interchange;
+  or,
+- **b)** Accompany it with a written offer, valid for at least three
+  years, to give any third party, for a charge no more than your cost
+  of physically performing source distribution, a complete
+  machine-readable copy of the corresponding source code, to be
+  distributed under the terms of Sections 1 and 2 above on a medium
+  customarily used for software interchange; or,
+- **c)** Accompany it with the information you received as to the
+  offer to distribute corresponding source code. (This alternative is
+  allowed only for noncommercial distribution and only if you received
+  the program in object code or executable form with such an offer, in
+  accord with Subsection b above.)
 
 The source code for a work means the preferred form of the work for
-making modifications to it.  For an executable work, complete source
+making modifications to it. For an executable work, complete source
 code means all the source code for all modules it contains, plus any
 associated interface definition files, plus the scripts used to
-control compilation and installation of the executable.  However, as a
+control compilation and installation of the executable. However, as a
 special exception, the source code distributed need not include
 anything that is normally distributed (in either source or binary
 form) with the major components (compiler, kernel, and so on) of the
@@ -167,42 +173,43 @@ distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
 
 **4.** You may not copy, modify, sublicense, or distribute the Program
-except as expressly provided under this License.  Any attempt
-otherwise to copy, modify, sublicense or distribute the Program is
-void, and will automatically terminate your rights under this License.
-However, parties who have received copies, or rights, from you under
-this License will not have their licenses terminated so long as such
+except as expressly provided under this License. Any attempt otherwise
+to copy, modify, sublicense or distribute the Program is void, and
+will automatically terminate your rights under this License. However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
 parties remain in full compliance.
 
 **5.** You are not required to accept this License, since you have not
-signed it.  However, nothing else grants you permission to modify or
-distribute the Program or its derivative works.  These actions are
-prohibited by law if you do not accept this License.  Therefore, by
+signed it. However, nothing else grants you permission to modify or
+distribute the Program or its derivative works. These actions are
+prohibited by law if you do not accept this License. Therefore, by
 modifying or distributing the Program (or any work based on the
 Program), you indicate your acceptance of this License to do so, and
 all its terms and conditions for copying, distributing or modifying
 the Program or works based on it.
 
-**6.** Each time you redistribute the Program (or any work based on the
-Program), the recipient automatically receives a license from the
+**6.** Each time you redistribute the Program (or any work based on
+the Program), the recipient automatically receives a license from the
 original licensor to copy, distribute or modify the Program subject to
-these terms and conditions.  You may not impose any further
+these terms and conditions. You may not impose any further
 restrictions on the recipients' exercise of the rights granted herein.
 You are not responsible for enforcing compliance by third parties to
 this License.
 
-**7.** If, as a consequence of a court judgment or allegation of patent
-infringement or for any other reason (not limited to patent issues),
-conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot
-distribute so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you
-may not distribute the Program at all.  For example, if a patent
-license would not permit royalty-free redistribution of the Program by
-all those who receive copies directly or indirectly through you, then
-the only way you could satisfy both it and this License would be to
-refrain entirely from distribution of the Program.
+**7.** If, as a consequence of a court judgment or allegation of
+patent infringement or for any other reason (not limited to patent
+issues), conditions are imposed on you (whether by court order,
+agreement or otherwise) that contradict the conditions of this
+License, they do not excuse you from the conditions of this License.
+If you cannot distribute so as to satisfy simultaneously your
+obligations under this License and any other pertinent obligations,
+then as a consequence you may not distribute the Program at all. For
+example, if a patent license would not permit royalty-free
+redistribution of the Program by all those who receive copies directly
+or indirectly through you, then the only way you could satisfy both it
+and this License would be to refrain entirely from distribution of the
+Program.
 
 If any portion of this section is held invalid or unenforceable under
 any particular circumstance, the balance of the section is intended to
@@ -213,7 +220,7 @@ It is not the purpose of this section to induce you to infringe any
 patents or other property right claims or to contest validity of any
 such claims; this section has the sole purpose of protecting the
 integrity of the free software distribution system, which is
-implemented by public license practices.  Many people have made
+implemented by public license practices. Many people have made
 generous contributions to the wide range of software distributed
 through that system in reliance on consistent application of that
 system; it is up to the author/donor to decide if he or she is willing
@@ -228,51 +235,53 @@ certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
 may add an explicit geographical distribution limitation excluding
 those countries, so that distribution is permitted only in or among
-countries not thus excluded.  In such case, this License incorporates
+countries not thus excluded. In such case, this License incorporates
 the limitation as if written in the body of this License.
 
-**9.** The Free Software Foundation may publish revised and/or new versions
-of the General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
+**9.** The Free Software Foundation may publish revised and/or new
+versions of the General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the Program
-specifies a version number of this License which applies to it and “any
-later version”, you have the option of following the terms and conditions
-either of that version or of any later version published by the Free
-Software Foundation.  If the Program does not specify a version number of
-this License, you may choose any version ever published by the Free Software
-Foundation.
+Each version is given a distinguishing version number. If the Program
+specifies a version number of this License which applies to it and
+“any later version”, you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation. If the Program does not specify a
+version number of this License, you may choose any version ever
+published by the Free Software Foundation.
 
-**10.** If you wish to incorporate parts of the Program into other free
-programs whose distribution conditions are different, write to the author
-to ask for permission.  For software which is copyrighted by the Free
-Software Foundation, write to the Free Software Foundation; we sometimes
-make exceptions for this.  Our decision will be guided by the two goals
-of preserving the free status of all derivatives of our free software and
-of promoting the sharing and reuse of software generally.
+**10.** If you wish to incorporate parts of the Program into other
+free programs whose distribution conditions are different, write to
+the author to ask for permission. For software which is copyrighted by
+the Free Software Foundation, write to the Free Software Foundation;
+we sometimes make exceptions for this. Our decision will be guided by
+the two goals of preserving the free status of all derivatives of our
+free software and of promoting the sharing and reuse of software
+generally.
 
 ### NO WARRANTY
 
-**11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
-FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
-OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
-PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
-OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
-TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
-PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
-REPAIR OR CORRECTION.
+**11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-**12.** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
-REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
-INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
-OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
-TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
-YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
-PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.
+**12.** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
 
 END OF TERMS AND CONDITIONS
 
@@ -280,57 +289,66 @@ END OF TERMS AND CONDITIONS
 
 If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
+free software which everyone can redistribute and change under these
+terms.
 
-To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
+To do so, attach the following notices to the program. It is safest to
+attach them to the start of each source file to most effectively
 convey the exclusion of warranty; and each file should have at least
 the “copyright” line and a pointer to where the full notice is found.
 
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-    
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
-    
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-    
-    You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+```
+<one line to give the program's name and a brief idea of what it does.>
+Copyright (C) <year>  <name of author>
 
-Also add information on how to contact you by electronic and paper mail.
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+```
+
+Also add information on how to contact you by electronic and paper
+mail.
 
 If the program is interactive, make it output a short notice like this
 when it starts in an interactive mode:
 
-    Gnomovision version 69, Copyright (C) year name of author
-    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
+```
+Gnomovision version 69, Copyright (C) year name of author
+Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `show c' for details.
+```
 
-The hypothetical commands `show w` and `show c` should show the appropriate
-parts of the General Public License.  Of course, the commands you use may
-be called something other than `show w` and `show c`; they could even be
-mouse-clicks or menu items--whatever suits your program.
+The hypothetical commands `show w` and `show c` should show the
+appropriate parts of the General Public License. Of course, the
+commands you use may be called something other than `show w` and
+`show c`; they could even be mouse-clicks or menu items--whatever
+suits your program.
 
-You should also get your employer (if you work as a programmer) or your
-school, if any, to sign a “copyright disclaimer” for the program, if
-necessary.  Here is a sample; alter the names:
+You should also get your employer (if you work as a programmer) or
+your school, if any, to sign a “copyright disclaimer” for the program,
+if necessary. Here is a sample; alter the names:
 
-    Yoyodyne, Inc., hereby disclaims all copyright interest in the program
-    `Gnomovision' (which makes passes at compilers) written by James Hacker.
-    
-    <signature of Ty Coon>, 1 April 1989
-    Ty Coon, President of Vice
+```
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+`Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-This General Public License does not permit incorporating your program into
-proprietary programs.  If your program is a subroutine library, you may
-consider it more useful to permit linking proprietary applications with the
-library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.
+<signature of Ty Coon>, 1 April 1989
+Ty Coon, President of Vice
+```
+
+This General Public License does not permit incorporating your program
+into proprietary programs. If your program is a subroutine library,
+you may consider it more useful to permit linking proprietary
+applications with the library. If this is what you want to do, use the
+GNU Lesser General Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -1,69 +1,127 @@
 # CAKE with Adaptive Bandwidth - "autorate"
 
-**CAKE-autorate** is a script that automatcially adjusts CAKE bandwidth settings based on traffic load and one-way-delay or round-trip-time measurements. CAKE-autorate is intended for variable bandwidth connections such as LTE, Starlink, and cable modems and is not generally required for use on connections that have a stable, fixed bandwidth.
+**CAKE-autorate** is a script that automatcially adjusts CAKE
+bandwidth settings based on traffic load and one-way-delay or
+round-trip-time measurements. CAKE-autorate is intended for variable
+bandwidth connections such as LTE, Starlink, and cable modems and is
+not generally required for use on connections that have a stable,
+fixed bandwidth.
 
-[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/) is an algorithm that manages the buffering of data being sent/received by a device such as an [OpenWrt router](https://openwrt.org) so that no more data is queued than is necessary, minimizing the latency ("bufferbloat") and improving the responsiveness of a network.
+[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/)
+is an algorithm that manages the buffering of data being sent/received
+by a device such as an [OpenWrt router](https://openwrt.org) so that
+no more data is queued than is necessary, minimizing the latency
+("bufferbloat") and improving the responsiveness of a network.
 
-Present version is 2.0.0 - please see [the changelog](CHANGELOG.md) for details.
+Present version is 2.0.0 - please see [the changelog](CHANGELOG.md)
+for details.
 
 ## The Problem: CAKE on variable speed connections forces an unpalatable compromise
 
-The CAKE algorithm uses static upload and download bandwidth settings to manage its queues. Variable bandwidth connections present a challenge because the actual bandwidth at any given moment is not known.
+The CAKE algorithm uses static upload and download bandwidth settings
+to manage its queues. Variable bandwidth connections present a
+challenge because the actual bandwidth at any given moment is not
+known.
 
-Because CAKE works with fixed bandwidth parameters,  the user must choose a single compromise bandwidth setting. This compromise is not ideal: setting the parameter too low means the connection is unnecessarily throttled to the compromise setting even when the available link speed is higher (yellow). Setting the rate too high, for times when the usable line rate falls below the compromise value, means that the link is not throttled enough (green) resulting in bufferbloat.
+Because CAKE works with fixed bandwidth parameters, the user must
+choose a single compromise bandwidth setting. This compromise is not
+ideal: setting the parameter too low means the connection is
+unnecessarily throttled to the compromise setting even when the
+available link speed is higher (yellow). Setting the rate too high,
+for times when the usable line rate falls below the compromise value,
+means that the link is not throttled enough (green) resulting in
+bufferbloat.
 
 <img src="images/bandwidth-compromise.png" width=75% height=75%>
 
 ## The Solution: Set CAKE parameters based on _Load_ and _RTT_
 
-The CAKE-autorate script continually measures the load and One Way Delay or Round-Trip-Time (RTT) to adjust the upload and download settings for the CAKE algorithm.
+The CAKE-autorate script continually measures the load and One Way
+Delay or Round-Trip-Time (RTT) to adjust the upload and download
+settings for the CAKE algorithm.
 
 ### Theory of Operation
 
-`cake-autorate.sh` monitors load (receive and transmit utilization) and ping response times from one or more reflectors (hosts on the internet), and adjusts the download and upload bandwidth settings for CAKE.
+`cake-autorate.sh` monitors load (receive and transmit utilization)
+and ping response times from one or more reflectors (hosts on the
+internet), and adjusts the download and upload bandwidth settings for
+CAKE.
 
 CAKE-autorate uses this simple approach:
 
-- with low load, decay rate back to the configured baseline (and subject to refractory period)
+- with low load, decay rate back to the configured baseline (and
+  subject to refractory period)
 - with high load, increase rate subject to the configured maximum
-- if bufferbloat (increased latency) is detected, decrease rate subject to the configured min (and subject to refractory period)
+- if bufferbloat (increased latency) is detected, decrease rate
+  subject to the configured min (and subject to refractory period)
 
 <img src="images/cake-bandwidth-autorate-rate-control.png" width=80% height=80%>
 
-CAKE-autorate requires three configuration values for each direction, upload and download.
+CAKE-autorate requires three configuration values for each direction,
+upload and download.
 
-**Setting the minimum bandwidth:**
-Set the minimum value to the worst possible observed bufferbloat-free bandwidth. Ideally this setting should never result in bufferbloat even under the worst conditions. This is a hard minimum - the script will never reduce the bandwidth below this level.
+**Setting the minimum bandwidth:** Set the minimum value to the worst
+possible observed bufferbloat-free bandwidth. Ideally this setting
+should never result in bufferbloat even under the worst conditions.
+This is a hard minimum - the script will never reduce the bandwidth
+below this level.
 
-**Setting the baseline bandwidth:**
-This is the steady state bandwidth to be maintained under no or low load. This is likely the compromise bandwidth described above, i.e. the value you would set CAKE to that is bufferbloat free most, but not necessarily all, of the time.
+**Setting the baseline bandwidth:** This is the steady state bandwidth
+to be maintained under no or low load. This is likely the compromise
+bandwidth described above, i.e. the value you would set CAKE to that
+is bufferbloat free most, but not necessarily all, of the time.
 
-**Setting the maximum bandwidth:**
-The maximum bandwidth should be set to the maximum bandwdith the connection can provide or lower. When there is heavy traffic, the script will adjust the bandwidth up to this limit, and then back off if an OWD or RTT spike is detected. Since repeatedly testing for the maximum bandwidth on load necessarily involves letting some excess latency through, reducing the maximum bandwidth to a level below the maximum possible bandwidth has the benefit of reducing that excess latency associated with testing for the maximum bandwidth, and may allow for some degree of cruising along at that upper limit whilst the true conneciton capacity is higher than the set maximum bandwidth. 
+**Setting the maximum bandwidth:** The maximum bandwidth should be set
+to the maximum bandwdith the connection can provide or lower. When
+there is heavy traffic, the script will adjust the bandwidth up to
+this limit, and then back off if an OWD or RTT spike is detected.
+Since repeatedly testing for the maximum bandwidth on load necessarily
+involves letting some excess latency through, reducing the maximum
+bandwidth to a level below the maximum possible bandwidth has the
+benefit of reducing that excess latency associated with testing for
+the maximum bandwidth, and may allow for some degree of cruising along
+at that upper limit whilst the true conneciton capacity is higher than
+the set maximum bandwidth.
 
-To elaborate on setting the minimum and maximum, a variable bandwidth connection may be most ideally divided up into a known fixed, stable component, on top of which is provided an unknown variable component:
+To elaborate on setting the minimum and maximum, a variable bandwidth
+connection may be most ideally divided up into a known fixed, stable
+component, on top of which is provided an unknown variable component:
 
 ![image of cake bandwidth adaptation](images/cake-bandwidth-adaptation.png)
 
-The minimum bandwidth is then set to (or slightly below) the fixed component, and the maximum bandwidth may be set to (or slightly above) the maximum observed bandwidth (if maximum bandwidth is desired) or lower than the maximum observed bandwidth (if the user is willing to sacrifice some bandwidth in favour of reduced latency associated with always testing for the true maximum as explained above).
+The minimum bandwidth is then set to (or slightly below) the fixed
+component, and the maximum bandwidth may be set to (or slightly above)
+the maximum observed bandwidth (if maximum bandwidth is desired) or
+lower than the maximum observed bandwidth (if the user is willing to
+sacrifice some bandwidth in favour of reduced latency associated with
+always testing for the true maximum as explained above).
 
-The baseline bandwidth is likely optimally either the minimum bandwidth or somewhere close thereto (e.g. the compromise bandwidth).
+The baseline bandwidth is likely optimally either the minimum
+bandwidth or somewhere close thereto (e.g. the compromise bandwidth).
 
 ## Installation on OpenWrt
 
-Read the installation instructions in the separate [INSTALLATION](./INSTALLATION.md) page.
+Read the installation instructions in the separate
+[INSTALLATION](./INSTALLATION.md) page.
 
 ## Analysis of the CAKE-autorate logs
 
-CAKE-autorate maintains a detailed log file thats is helpful in discerning performance. 
+CAKE-autorate maintains a detailed log file thats is helpful in
+discerning performance.
 
 Read about this in the [ANALYSIS](./ANALYSIS.md) page.
 
 ## CPU load monitoring
 
-The user should verify that CPU load is kept within accpetable ranges, especially for devices with weaker CPUs.
+The user should verify that CPU load is kept within accpetable ranges,
+especially for devices with weaker CPUs.
 
-CAKE-autorate uses inter-process communication between multiple concurrent processes and incorporates various optimisations to reduce the CPU load nedded to perform its many tasks. A call to `ps |grep -e bash -e fping` reveals the presence of the multiple concurrent processes for each cake-autorate instance. This is normal and expected behaviour. 
+CAKE-autorate uses inter-process communication between multiple
+concurrent processes and incorporates various optimisations to reduce
+the CPU load nedded to perform its many tasks. A call to
+`ps |grep -e bash -e fping` reveals the presence of the multiple
+concurrent processes for each cake-autorate instance. This is normal
+and expected behaviour.
 
 ```bash
 root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
@@ -79,7 +137,8 @@ root@OpenWrt-1:~/cake-autorate# ps |grep -e bash -e fping
  2841 root      1928 S    fping --timestamp --loop --period 300 --interval 50 --timeout 10000 1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4 9.9.9.9 9
 ```
 
-Process IDs can be checked using `cat /var/run/cake-autorate/primary/proc_pids`, e.g.:
+Process IDs can be checked using
+`cat /var/run/cake-autorate/primary/proc_pids`, e.g.:
 
 ```bash
 root@OpenWrt-1:~# cat /var/run/cake-autorate/primary/proc_pids
@@ -93,8 +152,15 @@ maintain_pingers=8620
 parse_fping_pinger=21176
 ```
 
-It is useful to keep an htop instance running and run some speed tests to see the maximum CPU utilisation of the processes and keep an eye on the loadavg:
+It is useful to keep an htop instance running and run some speed tests
+to see the maximum CPU utilisation of the processes and keep an eye on
+the loadavg:
 
 ![image](https://github.com/lynxthecat/cake-autorate/assets/10721999/732ecdc0-e847-48db-baa5-c10616c2ad1b)
 
-CPU load is proportional to the frequency of ping responses. Reducing the number of pingers or pinger interval will therefore significantly reduce CPU usage. The default ping response rate is 20 Hz (6 pingers with 0.3 seconds between pings). Reducing the number of pingers to three will give a ping resposne rate of 10 Hz and approximately half the CPU load.
+CPU load is proportional to the frequency of ping responses. Reducing
+the number of pingers or pinger interval will therefore significantly
+reduce CPU usage. The default ping response rate is 20 Hz (6 pingers
+with 0.3 seconds between pings). Reducing the number of pingers to
+three will give a ping resposne rate of 10 Hz and approximately half
+the CPU load.


### PR DESCRIPTION
Add a wrap limit of 70 to all markdown documents to make reading
and more importantly editing/general maintainance (like comparing
diffs) easier.

This commit was generated using `mdformat --wrap 70 .`
