### PR TITLE
Use read -r in newly introduced code

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -279,7 +279,7 @@ flush_log_fd()
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
 	while read -r -t 0 -u "${log_fd}"
 	do
-		read -u "${log_fd}" log_line
+		read -r -u "${log_fd}" log_line
 		printf '%s\n' "${log_line}" >> "${log_file_path}"
 	done
 }


### PR DESCRIPTION
"Improve log file descriptor flush" dropped the -r switch from the read command.