### PR TITLE
fix: Delay startup before assigning initial timestamps

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -2036,6 +2036,13 @@ set_shaper_rate "ul"
 
 update_max_wire_packet_compensation
 
+# Wait if ${startup_wait_s} > 0
+if ((startup_wait_us>0))
+then
+	log_msg "DEBUG" "Waiting ${startup_wait_s} seconds before startup."
+	sleep_us "${startup_wait_us}"
+fi
+
 main_state="RUNNING"
 
 t_start_us="${EPOCHREALTIME/./}"
@@ -2077,13 +2084,6 @@ fi
 
 # Randomize reflectors array providing randomize_reflectors set to 1
 ((randomize_reflectors)) && randomize_array reflectors
-
-# Wait if ${startup_wait_s} > 0
-if ((startup_wait_us>0))
-then
-	log_msg "DEBUG" "Waiting ${startup_wait_s} seconds before startup."
-	sleep_us "${startup_wait_us}"
-fi
 
 case "${pinger_binary}" in
 


### PR DESCRIPTION
When startup_wait_s is non-zero, anything dependent upon initial timestamps (e.g., the reflector timeout period) will be affected by the sleep. If the reflector timeout period is less than the startup_wait_s duration. this causes a fatal crash immediately after the startup sleep ends.
This is addressed by sleeping before assigning any initial timestamps.