### PR TITLE
Use /usr/bin/env everywhere when spawning bash

### DIFF
--- a/Example_Starlink_config.sh
+++ b/Example_Starlink_config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # *** STANDARD CONFIGURATION OPTIONS ***
 

--- a/cake-autorate
+++ b/cake-autorate
@@ -1,19 +1,12 @@
-#!/bin/bash /etc/rc.common
+#!/bin/sh /etc/rc.common
 
 START=97
 STOP=4
 USE_PROCD=1
 
 start_service() {
-
-        cake_instances=(/root/cake-autorate/config.*.sh)
-
-        for cake_instance in "${!cake_instances[@]}"
-        do
-                procd_open_instance "${cake_instance}"
-                procd_set_param command /root/cake-autorate/cake-autorate.sh "${cake_instances[cake_instance]}"
-                # uncomment if you want procd to restart your script if it terminated for whatever reason
-                #procd_set_param respawn
-                procd_close_instance
-        done
+        procd_open_instance
+        procd_set_param command /root/cake-autorate/launcher.sh
+        procd_set_param respawn
+        procd_close_instance
 }

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # cake-autorate automatically adjusts CAKE bandwidth(s)
 # in dependence on: a) receive and transmit transfer rates; and b) latency
@@ -212,7 +212,7 @@ reset_log_file()
 generate_log_file_scripts()
 {
 	cat > "${run_path}/log_file_export" <<- EOT
-	#!/bin/bash
+	#!/usr/bin/env bash
 
 	timeout_s=\${1:-20}
 
@@ -246,7 +246,7 @@ generate_log_file_scripts()
 	EOT
 
 	cat > "${run_path}/log_file_reset" <<- EOT
-	#!/bin/bash
+	#!/usr/bin/env bash
 
 	if kill -USR2 "${proc_pids['maintain_log_file']}"
 	then

--- a/config.primary.sh
+++ b/config.primary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # *** STANDARD CONFIGURATION OPTIONS ***
 

--- a/defaults.sh
+++ b/defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # defaults.sh -- default configuration values for cake-autorate.sh
 #

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cake_instances=(/root/cake-autorate/config.*.sh)
 cake_instance_pids=()

--- a/lib.sh
+++ b/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # lib.sh -- common functions for use by cake-autorate.sh
 #

--- a/maint/update_setupsh_branch.sh
+++ b/maint/update_setupsh_branch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/maint/version_bump.sh
+++ b/maint/version_bump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
This fixes AsusWRT support.