### PR TITLE
Increase idle thr & improve config documentation

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -52,6 +52,14 @@ required tools. To use it:
     |  `dl_if` | Interface that downloads data (often _ifb4-wan_) |
     |  `ul_if` | Interface that uploads (often _wan_)             |
 
+  - Choose whether cake-autorate should adjust the shaper rates
+    (disable for monitoring only):
+
+    |                Variable | Setting                                    |
+    | ----------------------: | :----------------------------------------- |
+    | `adjust_dl_shaper_rate` | enable (1) or disable (0) download shaping |
+    | `adjust_ul_shaper_rate` | enable (1) or disable (0) upload shaping   |
+
   - Set bandwidth variables as described in _config.primary.sh_.
 
     | Type | Download                   | Upload                     |
@@ -60,13 +68,11 @@ required tools. To use it:
     | Base | `base_dl_shaper_rate_kbps` | `base_ul_shaper_rate_kbps` |
     | Max. | `max_dl_shaper_rate_kbps`  | `max_ul_shaper_rate_kbps`  |
 
-  - Choose whether cake-autorate should adjust the shaper rates
-    (disable for monitoring only):
+  - Set connection idle variable as described in _config.primary.sh_.
 
-    |                Variable | Setting                                    |
-    | ----------------------: | :----------------------------------------- |
-    | `adjust_dl_shaper_rate` | enable (1) or disable (0) download shaping |
-    | `adjust_ul_shaper_rate` | enable (1) or disable (0) upload shaping   |
+    |                     Variable | Setting                                                  |
+    | ---------------------------: | :------------------------------------------------------- |
+    | `connection_active_thr_kbps` | threshold in Kbit/s below which dl/ul is considered idle |
 
 ## Configuration of cake-autorate
 
@@ -234,10 +240,10 @@ preserved, enter the files below to the OpenWrt router's
   _/root/cake-autorate/_ directory in the form:
 
 ```bash
-config.interface.sh
+config.instance.sh
 ```
 
-where 'interface' is replaced with e.g. 'primary', 'secondary', etc.
+where 'instance' is replaced with e.g. 'primary', 'secondary', etc.
 
 ## Example Starlink Configuration
 

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1816,7 +1816,7 @@ then
 		broken_log_file_path_override=${log_file_path_override}
 		log_file_path=/var/log/cake-autorate${instance_id:+.${instance_id}}.log
 		log_msg "ERROR" "Log file path override: '${broken_log_file_path_override}' does not exist. Exiting now."
-		exit
+		exit 1
 	fi
 	log_file_path=${log_file_path_override}/cake-autorate${instance_id:+.${instance_id}}.log
 else
@@ -1841,7 +1841,7 @@ then
 	then
 		log_msg "ERROR" "${run_path} already exists and an instance appears to be running with main process pid ${running_main_pid}. Exiting script."
 		trap - INT TERM EXIT
-		exit
+		exit 1
 	else
 		log_msg "DEBUG" "${run_path} already exists but no instance is running. Removing and recreating."
 		rm -r "${run_path}"
@@ -1856,19 +1856,20 @@ proc_pids['main']="${BASHPID}"
 no_reflectors=${#reflectors[@]}
 
 # Check ping binary exists
-command -v "${pinger_binary}" &> /dev/null || { log_msg "ERROR" "ping binary ${pinger_binary} does not exist. Exiting script."; exit; }
+command -v "${pinger_binary}" &> /dev/null || { log_msg "ERROR" "ping binary ${pinger_binary} does not exist. Exiting script."; exit 1; }
 
 # Check no_pingers <= no_reflectors
-(( no_pingers > no_reflectors )) && { log_msg "ERROR" "number of pingers cannot be greater than number of reflectors. Exiting script."; exit; }
+(( no_pingers > no_reflectors )) && { log_msg "ERROR" "number of pingers cannot be greater than number of reflectors. Exiting script."; exit 1; }
 
 # Check dl/if interface not the same
-[[ "${dl_if}" == "${ul_if}" ]] && { log_msg "ERROR" "download interface and upload interface are both set to: '${dl_if}', but cannot be the same. Exiting script."; exit; }
+[[ "${dl_if}" == "${ul_if}" ]] && { log_msg "ERROR" "download interface and upload interface are both set to: '${dl_if}', but cannot be the same. Exiting script."; exit 1; }
 
 # Check bufferbloat detection threshold not greater than window length
-(( bufferbloat_detection_thr > bufferbloat_detection_window )) && { log_msg "ERROR" "bufferbloat_detection_thr cannot be greater than bufferbloat_detection_window. Exiting script."; exit; }
+(( bufferbloat_detection_thr > bufferbloat_detection_window )) && { log_msg "ERROR" "bufferbloat_detection_thr cannot be greater than bufferbloat_detection_window. Exiting script."; exit 1; }
 
-(( connection_active_thr_kbps > min_dl_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_dl_shaper_rate_kbps. Exiting script."; exit; }
-(( connection_active_thr_kbps > min_ul_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_ul_shaper_rate_kbps. Exiting script."; exit; }
+# Check if connection_active_thr_kbps is greater than min dl/ul shaper rate
+(( connection_active_thr_kbps > min_dl_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_dl_shaper_rate_kbps. Exiting script."; exit 1; }
+(( connection_active_thr_kbps > min_ul_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_ul_shaper_rate_kbps. Exiting script."; exit 1; }
 
 # Passed error checks
 
@@ -2096,7 +2097,7 @@ case "${pinger_binary}" in
 
 	*)
 		log_msg "ERROR" "Unknown pinger binary: ${pinger_binary}"
-		exit
+		exit 1
 		;;
 esac
 

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1867,6 +1867,9 @@ command -v "${pinger_binary}" &> /dev/null || { log_msg "ERROR" "ping binary ${p
 # Check bufferbloat detection threshold not greater than window length
 (( bufferbloat_detection_thr > bufferbloat_detection_window )) && { log_msg "ERROR" "bufferbloat_detection_thr cannot be greater than bufferbloat_detection_window. Exiting script."; exit; }
 
+(( connection_active_thr_kbps > min_dl_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_dl_shaper_rate_kbps. Exiting script."; exit; }
+(( connection_active_thr_kbps > min_ul_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_ul_shaper_rate_kbps. Exiting script."; exit; }
+
 # Passed error checks
 
 if ((log_to_file))

--- a/config.primary.sh
+++ b/config.primary.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
-# *** STANDARD CONFIGURATION OPTIONS ***
+# *** INSTANCE-SPECIFIC CONFIGURATION OPTIONS ***
+# 
+# cake-autorate will run one instance per config file present in the /root/cake-autorate
+# directory in the form: config.instance.sh. Thus multiple instances of cake-autorate
+# can be established by setting up appropriate config files like config.primary.sh and 
+# config.secondary.sh for the respective first and second instances of cake-autorate.
 
 ### For multihomed setups, it is the responsibility of the user to ensure that the probes
 ### sent by this instance of cake-autorate actually travel through these interfaces.
@@ -21,6 +26,8 @@ max_dl_shaper_rate_kbps=80000  # maximum bandwidth for download (Kbit/s)
 min_ul_shaper_rate_kbps=5000  # minimum bandwidth for upload (Kbit/s)
 base_ul_shaper_rate_kbps=20000 # steady state bandwidth for upload (KBit/s)
 max_ul_shaper_rate_kbps=35000  # maximum bandwidth for upload (Kbit/s)
+
+connection_active_thr_kbps=2000  # threshold in Kbit/s below which dl/ul is considered idle
 
 # *** OVERRIDES ***
 

--- a/defaults.sh
+++ b/defaults.sh
@@ -102,7 +102,7 @@ max_ul_shaper_rate_kbps=35000  # maximum bandwidth for upload (Kbit/s)
 # sleep functionality saves unecessary pings and CPU cycles by
 # pausing all active pingers when connection is not in active use
 enable_sleep_function=1 # enable (1) or disable (0) sleep functonality
-connection_active_thr_kbps=1000  # threshold in Kbit/s below which dl/ul is considered idle
+connection_active_thr_kbps=2000  # threshold in Kbit/s below which dl/ul is considered idle
 sustained_idle_sleep_thr_s=60.0  # time threshold to put pingers to sleep on sustained dl/ul achieved rate < idle_thr (seconds)
 
 min_shaper_rates_enforcement=0 # enable (1) or disable (0) dropping down to minimum shaper rates on connection idle or stall


### PR DESCRIPTION
The default idle threshold of 1MBit/s seems to be too low for a typical set of home IoT devices, resulting in the sleep activation logic never triggering  - see [here](https://forum.openwrt.org/t/cake-w-adaptive-bandwidth/135379/3507). In any case, it seems apt to add this as one of the configuration options present in config.primary.sh.

And the term 'instance' is more appropriate than 'interface' in respect of config.x.sh.