### PR TITLE
Update "scp" command for latest OpenSSH version

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -83,7 +83,7 @@ from the router and generate the pdfs for viewing from the remote
 machine:
 
 ```bash
-log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"
+log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp -O root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"
 octave -qf --eval 'fn_parse_autorate_log("./*primary*log.gz", "./output.pdf")'
 ```
 


### PR DESCRIPTION
With the latest OpenSSH version, scp is now just a wrapper to sftp. The issue with that is that the sftp binaries are not present in OpenWRT by default. As a solution, we specify `-O` which allows us to use the the actual SCP protocol.