### PR TITLE
Update ANALYSIS.md export instructions to use PNG not PDF

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -75,7 +75,7 @@ The command below will run the Octave program (see the introductory
 notes in _fn_parse_autorate_log.m_ for more details):
 
 ```bash
-octave -qf --eval 'fn_parse_autorate_log("./log.gz", "./output.pdf")'
+octave -qf --eval 'fn_parse_autorate_log("./log.gz", "./output.png")'
 ```
 
 The script below can be run on a remote machine to extract the log
@@ -84,7 +84,7 @@ machine:
 
 ```bash
 log_file=$(ssh root@192.168.1.1 '/var/run/cake-autorate/primary/log_file_export 1>/dev/null && cat /var/run/cake-autorate/primary/last_log_file_export') && scp -O root@192.168.1.1:${log_file} . && ssh root@192.168.1.1 "rm ${log_file}"
-octave -qf --eval 'fn_parse_autorate_log("./*primary*log.gz", "./output.pdf")'
+octave -qf --eval 'fn_parse_autorate_log("./*primary*log.gz", "./output.png")'
 ```
 
 ### Prometheus cake-autorate exporter

--- a/fn_parse_autorate_log.m
+++ b/fn_parse_autorate_log.m
@@ -186,7 +186,7 @@ function [ ] = fn_parse_autorate_log( log_FQN, plot_FQN, x_range_sec, selected_r
 		min_sequence_number = 1;
 
 		align_rate_and_delay_zeros = 1; % so that delay and rate 0s are aligned
-		output_format_extension = '.png'; % '.pdf', '.png', '.tif', '.ps
+		output_format_extension = '.png'; % '.pdf', '.png', '.tif', '.ps', ...
 		line_width = 1.0;
 		figure_opts.line_width = line_width;
 		figure_opts.output_format_extension = output_format_extension;
@@ -787,7 +787,7 @@ function [ autorate_log, log_FQN ] = fn_parse_autorate_logfile( log_FQN, command
 	log_struct.INFO = [];
 	log_struct.SHAPER = [];
 	log_struct.metainformation = [];
-  log_struct.SUMMARY_HEADER = [];
+	log_struct.SUMMARY_HEADER = [];
 	log_struct.SUMMARY = [];
 
 


### PR DESCRIPTION
From @moeller0:

The issue is that recent Octave/Ghostscript combinations crash while trying to export the timecourse plot. The PNG exporter however does seem to work.

-------------------

I also made some miscellaneous changes to the Octave script like having it use CRLF endings consistently and fixed an trivial formatting issue in initialization section of log_struct.