### PR TITLE
Add an Octave formatter and make our script compliant with formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+cake-autorate.*.log
+cake-autorate.*.log.gz
+cake-autorate.*.log.mat
+output.*.*

--- a/fn_parse_autorate_log.m
+++ b/fn_parse_autorate_log.m
@@ -33,7 +33,7 @@ function [ ] = fn_parse_autorate_log( log_FQN, plot_FQN, x_range_sec, selected_r
 
 %if ~(isoctave)
 dbstop if error;
-%end
+%endif
 
 timestamps.(mfilename).start = tic;
 fq_mfilename = mfilename('fullpath');
@@ -153,7 +153,7 @@ try
 		if (n_DATA_samples == 0)
 			x_range.DATA = x_range.LOAD; % needed for plot naming...
 		endif
-	end
+	endif
 	if (do_return)
 		return
 	endif
@@ -223,13 +223,13 @@ try
 		%				rates.LOAD.color_list{end+1} = [241,182,218]/254;
 		%				rates.LOAD.linestyle_list{end+1} = '-';
 		%				rates.LOAD.sign_list{end+1} = 1;
-		%			end
+		%			endif
 		%			if isfield(autorate_log.DATA.LISTS, 'CAKE_UL_RATE_KBPS')
 		%				rates.LOAD.fields_to_plot_list{end+1} = 'CAKE_UL_RATE_KBPS';
 		%				rates.LOAD.color_list{end+1} = [184,225,134]/254;
 		%				rates.LOAD.linestyle_list{end+1} = '-';
 		%				rates.LOAD.sign_list{end+1} = -1;
-		%			end
+		%			endif
 
 		% these can be replaced...
 		if isfield(autorate_log.LOAD.LISTS, 'DL_ACHIEVED_RATE_KBPS')
@@ -242,7 +242,7 @@ try
 			rates.DATA.color_list(rate_DATA_idx) = [];
 			rates.DATA.linestyle_list(rate_DATA_idx) = [];
 			rates.DATA.sign_list(rate_DATA_idx) = [];
-		end
+		endif
 		if isfield(autorate_log.LOAD.LISTS, 'UL_ACHIEVED_RATE_KBPS')
 			rates.LOAD.fields_to_plot_list{end+1} = 'UL_ACHIEVED_RATE_KBPS';
 			rates.LOAD.color_list{end+1} = [77,172,38]/254;
@@ -253,7 +253,7 @@ try
 			rates.DATA.color_list(rate_DATA_idx) = [];
 			rates.DATA.linestyle_list(rate_DATA_idx) = [];
 			rates.DATA.sign_list(rate_DATA_idx) = [];
-		end
+		endif
 	endif
 
 	% create the latency data ollection and configuration
@@ -270,42 +270,42 @@ try
 		delays.DATA.color_list{end+1} = [246, 232, 195]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = 1;
-	end
+	endif
 
 	if isfield(autorate_log.DATA.LISTS, 'UL_OWD_BASELINE')
 		delays.DATA.fields_to_plot_list{end+1} = 'UL_OWD_BASELINE';
 		delays.DATA.color_list{end+1} = [199, 234, 229]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = -1;
-	end
+	endif
 
 	if isfield(autorate_log.DATA.LISTS, 'DL_OWD_US')
 		delays.DATA.fields_to_plot_list{end+1} = 'DL_OWD_US';
 		delays.DATA.color_list{end+1} = [223, 194, 125]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = 1;
-	end
+	endif
 
 	if isfield(autorate_log.DATA.LISTS, 'UL_OWD_US')
 		delays.DATA.fields_to_plot_list{end+1} = 'UL_OWD_US';
 		delays.DATA.color_list{end+1} = [128, 205, 193]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = -1;
-	end
+	endif
 
 	if isfield(autorate_log.DATA.LISTS, 'DL_OWD_DELTA_US')
 		delays.DATA.fields_to_plot_list{end+1} = 'DL_OWD_DELTA_US';
 		delays.DATA.color_list{end+1} = [191, 129, 45]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = 1;
-	end
+	endif
 
 	if isfield(autorate_log.DATA.LISTS, 'UL_OWD_DELTA_US')
 		delays.DATA.fields_to_plot_list{end+1} = 'UL_OWD_DELTA_US';
 		delays.DATA.color_list{end+1} = [53, 151, 143]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = -1;
-	end
+	endif
 
 
 	if isfield(autorate_log.DATA.LISTS, 'DL_AVG_OWD_DELTA_US')
@@ -313,14 +313,14 @@ try
 		delays.DATA.color_list{end+1} = [0.33, 0 , 0]; %[191, 129, 45]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = 1;
-	end
+	endif
 
 	if isfield(autorate_log.DATA.LISTS, 'UL_AVG_OWD_DELTA_US')
 		delays.DATA.fields_to_plot_list{end+1} = 'UL_AVG_OWD_DELTA_US';
 		delays.DATA.color_list{end+1} = [0.33, 0 , 0]; %[53, 151, 143]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = -1;
-	end
+	endif
 
 
 
@@ -375,14 +375,14 @@ try
 		delays.DATA.color_list{end+1} = [140, 81, 10]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = 1;
-	end
+	endif
 
 	if isfield(autorate_log.DATA.LISTS, 'UL_OWD_DELTA_EWMA_US')
 		delays.DATA.fields_to_plot_list{end+1} = 'UL_OWD_DELTA_EWMA_US';
 		delays.DATA.color_list{end+1} = [1, 102, 94]/254;
 		delays.DATA.linestyle_list{end+1} = '-';
 		delays.DATA.sign_list{end+1} = -1;
-	end
+	endif
 
 
 	% get x_vector data and which indices to display for each record type
@@ -460,7 +460,7 @@ try
 		adjusted_ylim_delay(2) = (sign(delays.DATA.sign_list{1}) * dl_max_adj_delay_thr * scale_delay_axis_by_ADJ_DELAY_THR_factor);
 		disp(['INFO: Adjusted y-limits based on ADJ_DELAY_THR_factor: ', num2str(adjusted_ylim_delay)]);
 		%set(AX(2), 'YLim', (adjusted_ylim_delay * delays.DATA.scale_factor));
-	end
+	endif
 
 	% find the 99%ile for the actual relevant delay data
 
@@ -611,7 +611,7 @@ try
 
 			if ~isempty(adjusted_ylim_delay)
 				set(AX(1), 'YLim', (adjusted_ylim_delay * delays.DATA.scale_factor));
-			end
+			endif
 
 			hold(AX(2));
 			for i_field = 1 : length(rates.DATA.fields_to_plot_list)
@@ -689,12 +689,12 @@ try
 					legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
 				else
 					legend(legend_list, 'Interpreter', 'none', 'numcolumns', 2, 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
-				end
+				endif
 			catch
 				disp(['Triggered']);
 				legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'FontSize', 7);
 			end_try_catch
-		end
+		endif
 		hold off
 		xlabel(x_label_string);
 		ylabel('Rate [Mbps]');
@@ -719,11 +719,11 @@ try
 						legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
 					else
 						legend(legend_list, 'Interpreter', 'none', 'numcolumns', 3, 'box', 'off', 'location', 'northoutside', 'FontSize', 7);
-					end
+					endif
 				catch
 					legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'FontSize', 7);
 				end_try_catch
-			end
+			endif
 			hold off
 			xlabel(x_label_string);
 			ylabel('Delay [milliseconds]');
@@ -894,7 +894,7 @@ save(fullfile(log_dir, [log_name, log_ext, '.mat']), 'autorate_log', '-7');
 if ~exist(fullfile(log_dir, [log_name, log_ext, '.gz']), 'file')
 	% compress the uncompressed log
 	FILELIST = gzip(fullfile(log_dir, [log_name, log_ext]));
-end
+endif
 
 if exist(fullfile(log_dir, [log_name, log_ext]), 'file');
 	% delete the uncompressed log
@@ -910,7 +910,7 @@ persistent inout;
 
 if isempty(inout),
 	inout = exist('OCTAVE_VERSION','builtin') ~= 0;
-end
+endif
 in = inout;
 
 return;
@@ -931,7 +931,7 @@ sanitized_name = input_name;
 taboo_first_char_idx = find(ismember(taboo_first_char_list, input_name(1)));
 if ~isempty(taboo_first_char_idx)
 	sanitized_name = [replacement_firts_char_list{taboo_first_char_idx}, input_name(2:end)];
-end
+endif
 
 for i_taboo_char = 1: length(taboo_char_list)
 	current_taboo_string = taboo_char_list{i_taboo_char};
@@ -947,10 +947,10 @@ for i_taboo_char = 1: length(taboo_char_list)
 			% we add one superfluous replacement string at the end, so
 			% remove that
 			tmp_string = tmp_string(1:end-length(current_replacement_string));
-		end
-	end
+		endif
+	endwhile
 	sanitized_name = tmp_string;
-end
+endfor
 
 return
 endfunction
@@ -1333,7 +1333,7 @@ for i_field = 1 : length(cell_array_of_field_names)
 
 	%strcmp(log_struct.DATA.listnames{i_field}, 'TYPE')
 	log_struct.(DATA_RECORD_name).listtypes{i_field} = cur_type_string;
-end
+endfor
 
 log_struct.(DATA_RECORD_name).format_string = fn_compose_format_string(log_struct.(DATA_RECORD_name).listtypes);
 
@@ -1396,7 +1396,7 @@ if (ismember(version('-release'), {'2016a', '2019a', '2019b'}))
 	set(img_fh, 'PaperPositionMode', 'manual');
 	if ~ismember(img_type, {'.png', '.tiff', '.tif'})
 		print_options_str = '-bestfit';
-	end
+	endif
 endif
 
 if ~exist('print_options_str', 'var') || isempty(print_options_str)
@@ -1474,7 +1474,7 @@ output_rect = [];
 
 if ~ ishandle(figure_handle)
 	error(['ERROR: First argument needs to be a figure handle...']);
-end
+endif
 
 cm2inch = 1/2.54;
 fraction = 1;
@@ -1633,7 +1633,7 @@ try
 		legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'location', 'eastoutside', 'FontSize', legend_font_size);
 	else
 		legend(legend_list, 'Interpreter', 'none', 'numcolumns', 1, 'box', 'off', 'location', 'eastoutside', 'FontSize', legend_font_size);
-	end
+	endif
 catch
 	disp(['Triggered']);
 	legend(legend_list, 'Interpreter', 'none', 'box', 'off', 'FontSize', legend_font_size);

--- a/maint/octave_formatter.py
+++ b/maint/octave_formatter.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+
+"""
+Modified from matlab-formatter-vscode to add GNU Octave support and to adapt
+it to cake-autorate's needs (i.e., we added some features like inplace, tabs,
+argparse, etc.)
+
+Based on https://github.com/affenwiesel/matlab-formatter-vscode commit 43d7224.
+
+For reference on what needs to be modified, see
+https://en.wikibooks.org/wiki/MATLAB_Programming/Differences_between_Octave_and_MATLAB
+
+Copyright(C) 2019-2021 Benjamin "Mogli" Mann
+Copyright(C) 2022 Linuxbckp
+Copyright(C) 2024 Rany <rany@riseup.net>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import argparse
+import re
+import sys
+
+
+class Formatter:
+    # control sequences
+    ctrl_1line = re.compile(
+        r"(\s*)(if|while|for|try)(\W\s*\S.*\W)((end|endif|endwhile|endfor|end_try_catch);?)(\s+\S.*|\s*$)"
+    )
+    ctrl_1line_dountil = re.compile(r"(^|\s*)(do)(\W\S.*\W)(until)\s*(\W\S.*|\s*$)")
+    fcnstart = re.compile(r"(\s*)(function|classdef)\s*(\W\s*\S.*|\s*$)")
+    ctrlstart = re.compile(
+        r"(\s*)(if|while|for|parfor|try|methods|properties|events|arguments|enumeration|do|spmd)\s*(\W\s*\S.*|\s*$)"
+    )
+    ctrl_ignore = re.compile(r"(\s*)(import|clear|clearvars)(.*$)")
+    ctrlstart_2 = re.compile(r"(\s*)(switch)\s*(\W\s*\S.*|\s*$)")
+    ctrlcont = re.compile(r"(\s*)(elseif|else|case|otherwise|catch)\s*(\W\s*\S.*|\s*$)")
+    ctrlend = re.compile(
+        r"(\s*)((end|endfunction|endif|endwhile|endfor|end_try_catch|endswitch|until|endclassdef|endmethods|endproperties);?)(\s+\S.*|\s*$)"
+    )
+    linecomment = re.compile(r"(\s*)[%#].*$")
+    ellipsis = re.compile(r".*\.\.\..*$")
+    blockcomment_open = re.compile(r"(\s*)%\{\s*$")
+    blockcomment_close = re.compile(r"(\s*)%\}\s*$")
+    block_close = re.compile(r"\s*[\)\]\}].*$")
+    ignore_command = re.compile(r".*formatter\s+ignore\s+(\d*).*$")
+
+    # patterns
+    p_string = re.compile(
+        r"(.*?[\(\[\{,;=\+\-\*\/\|\&\s]|^)\s*(\'([^\']|\'\')+\')([\)\}\]\+\-\*\/=\|\&,;].*|\s+.*|$)"
+    )
+    p_string_dq = re.compile(
+        r"(.*?[\(\[\{,;=\+\-\*\/\|\&\s]|^)\s*(\"([^\"])*\")([\)\}\]\+\-\*\/=\|\&,;].*|\s+.*|$)"
+    )
+    p_comment = re.compile(r"(.*\S|^)\s*([%#].*)")
+    p_blank = re.compile(r"^\s+$")
+    p_num_sc = re.compile(r"(.*?\W|^)\s*(\d+\.?\d*)([eE][+-]?)(\d+)(.*)")
+    p_num_R = re.compile(r"(.*?\W|^)\s*(\d+)\s*(\/)\s*(\d+)(.*)")
+    p_incr = re.compile(r"(.*?\S|^)\s*(\+|\-)\s*(\+|\-)\s*([\)\]\},;].*|$)")
+    p_sign = re.compile(r"(.*?[\(\[\{,;:=\*/\s]|^)\s*(\+|\-)(\w.*)")
+    p_colon = re.compile(r"(.*?\S|^)\s*(:)\s*(\S.*|$)")
+    p_ellipsis = re.compile(r"(.*?\S|^)\s*(\.\.\.)\s*(\S.*|$)")
+    p_op_dot = re.compile(r"(.*?\S|^)\s*(\.)\s*(\+|\-|\*|/|\^)\s*(=)\s*(\S.*|$)")
+    p_pow_dot = re.compile(r"(.*?\S|^)\s*(\.)\s*(\^)\s*(\S.*|$)")
+    p_pow = re.compile(r"(.*?\S|^)\s*(\^)\s*(\S.*|$)")
+    p_op_comb = re.compile(
+        r"(.*?\S|^)\s*(\.|\+|\-|\*|\\|/|=|<|>|\||\&|!|~|\^)\s*(<|>|=|\+|\-|\*|/|\&|\|)\s*(\S.*|$)"
+    )
+    p_not = re.compile(r"(.*?\S|^)\s*(!|~)\s*(\S.*|$)")
+    p_op = re.compile(r"(.*?\S|^)\s*(\+|\-|\*|\\|/|=|!|~|<|>|\||\&)\s*(\S.*|$)")
+    p_func = re.compile(r"(.*?\w)(\()\s*(\S.*|$)")
+    p_open = re.compile(r"(.*?)(\(|\[|\{)\s*(\S.*|$)")
+    p_close = re.compile(r"(.*?\S|^)\s*(\)|\]|\})(.*|$)")
+    p_comma = re.compile(r"(.*?\S|^)\s*(,|;)\s*(\S.*|$)")
+    p_multiws = re.compile(r"(.*?\S|^)(\s{2,})(\S.*|$)")
+
+    def cell_indent(self, line, cell_open: str, cell_close: str, indent):
+        # clean line from strings and comments
+        pattern = re.compile(rf"(\s*)((\S.*)?)(\{cell_open}.*$)")
+        line = self.clean_line_from_strings_and_comments(line)
+        opened = line.count(cell_open) - line.count(cell_close)
+        if opened > 0:
+            m = pattern.match(line)
+            n = len(m.group(2))
+            indent = (n + 1) if self.matrix_indent else self.iwidth
+        elif opened < 0:
+            indent = 0
+        return (opened, indent)
+
+    def multilinematrix(self, line):
+        tmp, self.matrix = self.cell_indent(line, "[", "]", self.matrix)
+        return tmp
+
+    def cellarray(self, line):
+        tmp, self.cell = self.cell_indent(line, "{", "}", self.cell)
+        return tmp
+
+    # indentation
+    ilvl = 0
+    istep = []
+    fstep = []
+    iwidth = 0
+    matrix = 0
+    cell = 0
+    isblockcomment = 0
+    islinecomment = 0
+    longline = 0
+    continueline = 0
+    is_comment = 0
+    separate_blocks = False
+    ignore_lines = 0
+
+    def __init__(
+        self,
+        indent_width,
+        separate_blocks,
+        indent_mode,
+        operator_sep,
+        matrix_indent,
+    ):
+        self.iwidth = indent_width
+        self.separate_blocks = separate_blocks
+        self.indent_mode = indent_mode
+        self.operator_sep = operator_sep
+        self.matrix_indent = matrix_indent
+
+    def clean_line_from_strings_and_comments(self, line):
+        split = self.extract_string_comment(line)
+        if split:
+            return (
+                self.clean_line_from_strings_and_comments(split[0])
+                + " "
+                + self.clean_line_from_strings_and_comments(split[2])
+            )
+        else:
+            return line
+
+    # divide string into three parts by extracting and formatting certain
+    # expressions
+
+    def extract_string_comment(self, part):
+        # comment
+        m = self.p_comment.match(part)
+        if m:
+            self.is_comment = 1
+            part = m.group(1) + " " + m.group(2)
+
+        # string
+        m = self.p_string.match(part)
+        m2 = self.p_string_dq.match(part)
+        # choose longer string to avoid extracting subexpressions
+        if m2 and (not m or len(m.group(2)) < len(m2.group(2))):
+            m = m2
+        if m:
+            return (m.group(1), m.group(2), m.group(4))
+
+        return 0
+
+    def extract(self, part):
+        # whitespace only
+        m = self.p_blank.match(part)
+        if m:
+            return ("", " ", "")
+
+        # string, comment
+        string_or_comment = self.extract_string_comment(part)
+        if string_or_comment:
+            return string_or_comment
+
+        # decimal number (e.g. 5.6E-3)
+        m = self.p_num_sc.match(part)
+        if m:
+            return (m.group(1) + m.group(2), m.group(3), m.group(4) + m.group(5))
+
+        # rational number (e.g. 1/4)
+        m = self.p_num_R.match(part)
+        if m:
+            return (m.group(1) + m.group(2), m.group(3), m.group(4) + m.group(5))
+
+        # incrementor (++ or --)
+        m = self.p_incr.match(part)
+        if m:
+            return (m.group(1), m.group(2) + m.group(3), m.group(4))
+
+        # signum (unary - or +)
+        m = self.p_sign.match(part)
+        if m:
+            return (m.group(1), m.group(2), m.group(3))
+
+        # colon
+        m = self.p_colon.match(part)
+        if m:
+            return (m.group(1), m.group(2), m.group(3))
+
+        # dot-operator-assignment (e.g. .+=)
+        m = self.p_op_dot.match(part)
+        if m:
+            sep = " " if self.operator_sep > 0 else ""
+            return (
+                m.group(1) + sep,
+                m.group(2) + m.group(3) + m.group(4),
+                sep + m.group(5),
+            )
+
+        # .power (.^)
+        m = self.p_pow_dot.match(part)
+        if m:
+            sep = " " if self.operator_sep > 0.5 else ""
+            return (m.group(1) + sep, m.group(2) + m.group(3), sep + m.group(4))
+
+        # power (^)
+        m = self.p_pow.match(part)
+        if m:
+            sep = " " if self.operator_sep > 0.5 else ""
+            return (m.group(1) + sep, m.group(2), sep + m.group(3))
+
+        # combined operator (e.g. +=, .+, etc.)
+        m = self.p_op_comb.match(part)
+        if m:
+            # sep = ' ' if m.group(3) == '=' or self.operatorSep > 0 else ''
+            sep = " " if self.operator_sep > 0 else ""
+            return (m.group(1) + sep, m.group(2) + m.group(3), sep + m.group(4))
+
+        # not (~ or !)
+        m = self.p_not.match(part)
+        if m:
+            return (m.group(1) + " ", m.group(2), m.group(3))
+
+        # single operator (e.g. +, -, etc.)
+        m = self.p_op.match(part)
+        if m:
+            # sep = ' ' if m.group(2) == '=' or self.operatorSep > 0 else ''
+            sep = " " if self.operator_sep > 0 else ""
+            return (m.group(1) + sep, m.group(2), sep + m.group(3))
+
+        # function call
+        m = self.p_func.match(part)
+        if m:
+            return (m.group(1), m.group(2), m.group(3))
+
+        # parenthesis open
+        m = self.p_open.match(part)
+        if m:
+            return (m.group(1), m.group(2), m.group(3))
+
+        # parenthesis close
+        m = self.p_close.match(part)
+        if m:
+            return (m.group(1), m.group(2), m.group(3))
+
+        # comma/semicolon
+        m = self.p_comma.match(part)
+        if m:
+            return (m.group(1), m.group(2), " " + m.group(3))
+
+        # ellipsis
+        m = self.p_ellipsis.match(part)
+        if m:
+            return (m.group(1) + " ", m.group(2), " " + m.group(3))
+
+        # multiple whitespace
+        m = self.p_multiws.match(part)
+        if m:
+            return (m.group(1), " ", m.group(3))
+
+        return 0
+
+    # recursively format string
+    def format(self, part):
+        m = self.extract(part)
+        if m:
+            return self.format(m[0]) + m[1] + self.format(m[2])
+        return part
+
+    # compute indentation
+    def indent(self, add_space=0):
+        indnt = ((self.ilvl + self.continueline) * self.iwidth + add_space) * " "
+        return indnt
+
+    # take care of indentation and call format(line)
+    def format_line(self, line):
+
+        if self.ignore_lines > 0:
+            self.ignore_lines -= 1
+            return (0, self.indent() + line.strip())
+
+        # determine if linecomment
+        if re.match(self.linecomment, line):
+            self.islinecomment = 2
+        else:
+            # we also need to track whether the previous line was a commment
+            self.islinecomment = max(0, self.islinecomment - 1)
+
+        # determine if blockcomment
+        if re.match(self.blockcomment_open, line):
+            self.isblockcomment = float("inf")
+        elif re.match(self.blockcomment_close, line):
+            self.isblockcomment = 1
+        else:
+            self.isblockcomment = max(0, self.isblockcomment - 1)
+
+        # find ellipsis
+        self.is_comment = 0
+        stripped_line = self.clean_line_from_strings_and_comments(line)
+        ellipsis_in_comment = self.islinecomment == 2 or self.isblockcomment
+        if re.match(self.block_close, stripped_line) or ellipsis_in_comment:
+            self.continueline = 0
+        else:
+            self.continueline = self.longline
+        if re.match(self.ellipsis, stripped_line) and not ellipsis_in_comment:
+            self.longline = 1
+        else:
+            self.longline = 0
+
+        # find comments
+        if self.isblockcomment:
+            return (0, line.rstrip())  # don't modify indentation in block comments
+        if self.islinecomment == 2:
+            # check for ignore statement
+            m = re.match(self.ignore_command, line)
+            if m:
+                if m.group(1) and int(m.group(1)) > 1:
+                    self.ignore_lines = int(m.group(1))
+                else:
+                    self.ignore_lines = 1
+            return (0, self.indent() + line.strip())
+
+        # find imports, clear, etc.
+        m = re.match(self.ctrl_ignore, line)
+        if m:
+            return (0, self.indent() + line.strip())
+
+        # find matrices
+        tmp = self.matrix
+        if self.multilinematrix(line) or tmp:
+            return (0, self.indent(tmp) + self.format(line).strip())
+
+        # find cell arrays
+        tmp = self.cell
+        if self.cellarray(line) or tmp:
+            return (0, self.indent(tmp) + self.format(line).strip())
+
+        # find control structures
+        m = re.match(self.ctrl_1line, line)
+        if m:
+            return (
+                0,
+                self.indent()
+                + m.group(2)
+                + " "
+                + self.format(m.group(3)).strip()
+                + " "
+                + m.group(4)
+                + " "
+                + self.format(m.group(6)).strip(),
+            )
+
+        m = re.match(self.fcnstart, line)
+        if m:
+            offset = self.indent_mode
+            self.fstep.append(1)
+            if self.indent_mode == -1:
+                offset = int(len(self.fstep) > 1)
+            return (
+                offset,
+                self.indent() + m.group(2) + " " + self.format(m.group(3)).strip(),
+            )
+
+        m = re.match(self.ctrl_1line_dountil, line)
+        if m:
+            return (
+                0,
+                self.indent()
+                + m.group(2)
+                + " "
+                + self.format(m.group(3)).strip()
+                + " "
+                + m.group(4)
+                + " "
+                + m.group(5),
+            )
+
+        m = re.match(self.ctrl_1line_dountil, line)
+        if m:
+            return (
+                0,
+                self.indent()
+                + m.group(2)
+                + " "
+                + self.format(m.group(3)).strip()
+                + " "
+                + m.group(4)
+                + " "
+                + m.group(5),
+            )
+
+        m = re.match(self.ctrlstart, line)
+        if m:
+            self.istep.append(1)
+            return (
+                1,
+                self.indent() + m.group(2) + " " + self.format(m.group(3)).strip(),
+            )
+
+        m = re.match(self.ctrlstart_2, line)
+        if m:
+            self.istep.append(2)
+            return (
+                2,
+                self.indent() + m.group(2) + " " + self.format(m.group(3)).strip(),
+            )
+
+        m = re.match(self.ctrlcont, line)
+        if m:
+            return (
+                0,
+                self.indent(-self.iwidth)
+                + m.group(2)
+                + " "
+                + self.format(m.group(3)).strip(),
+            )
+
+        m = re.match(self.ctrlend, line)
+        if m:
+            if len(self.istep) > 0:
+                step = self.istep.pop()
+            elif len(self.fstep) > 0:
+                step = self.fstep.pop()
+            else:
+                print("There are more end-statements than blocks!", file=sys.stderr)
+                step = 0
+            return (
+                -step,
+                self.indent(-step * self.iwidth)
+                + m.group(2)
+                + " "
+                + self.format(m.group(4)).strip(),
+            )
+
+        return (0, self.indent() + self.format(line).strip())
+
+    # format file from line 'start' to line 'end'
+    def format_file(self, filename, start, end, inplace, use_tabs, use_crlf):
+        # read lines from file
+        wlines = rlines = []
+
+        if filename == "-":
+            with sys.stdin as f:
+                rlines = f.readlines()[start - 1 : end]
+        else:
+            with open(filename, "r", encoding="UTF-8") as f:
+                rlines = f.readlines()[start - 1 : end]
+
+        # take care of empty input
+        if not rlines:
+            rlines = [""]
+
+        # get initial indent lvl
+        p = r"(\s*)(.*)"
+        m = re.match(p, rlines[0])
+        if m:
+            self.ilvl = len(m.group(1)) // self.iwidth
+            rlines[0] = m.group(2)
+
+        blank = True
+        for line in rlines:
+            # remove additional newlines
+            if re.match(r"^\s*$", line):
+                if not blank:
+                    blank = True
+                    wlines.append("")
+                continue
+
+            # format line
+            (offset, line) = self.format_line(line)
+
+            # adjust indent lvl
+            self.ilvl = max(0, self.ilvl + offset)
+
+            # add newline before block
+            if (
+                self.separate_blocks
+                and offset > 0
+                and not blank
+                and not self.islinecomment
+            ):
+                wlines.append("")
+
+            # add formatted line
+            wlines.append(line.rstrip())
+
+            # add newline after block
+            if self.separate_blocks and offset < 0:
+                wlines.append("")
+                blank = True
+            else:
+                blank = False
+
+        # remove last line if blank
+        while wlines and not wlines[-1]:
+            wlines.pop()
+
+        # take care of empty output
+        if not wlines:
+            wlines = [""]
+
+        # convert spaces to tabs
+        if self.iwidth <= 0 and use_tabs:
+            print("Indent width must be greater than 0 to use tabs!", file=sys.stderr)
+            use_tabs = False
+        elif use_tabs:
+            wlines = [re.sub(r"^" + r" " * self.iwidth, "\t", line) for line in wlines]
+
+        # write output
+        if inplace:
+            if filename == "-":
+                print("Cannot write inplace to stdin!", file=sys.stderr)
+                return
+
+            if not (start == 1 and end is None):
+                print("Cannot write inplace to a slice of a file!", file=sys.stderr)
+                return
+
+            with open(
+                filename, "w", encoding="UTF-8", newline="\r\n" if use_crlf else "\n"
+            ) as f:
+                for line in wlines:
+                    f.write(line + "\n")
+        else:
+            for line in wlines:
+                print(line, end="\r\n" if use_crlf else "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="MATLAB formatter")
+    parser.add_argument("filename", help="input file")
+    parser.add_argument("--start-line", type=int, default=1, help="start line")
+    parser.add_argument("--end-line", type=int, help="end line")
+    parser.add_argument("--indent-width", type=int, default=4, help="indent width")
+    parser.add_argument(
+        "--use-tabs", action="store_true", help="use tabs instead of spaces"
+    )
+    parser.add_argument("--use-crlf", action="store_true", help="use CRLF line endings")
+    parser.add_argument(
+        "--separate-blocks", action="store_true", help="separate blocks"
+    )
+    parser.add_argument(
+        "--indent-mode",
+        choices=["all_functions", "only_nested_functions", "classic"],
+        default="all_functions",
+        help="indent mode",
+    )
+    parser.add_argument(
+        "--add-space",
+        choices=["all_operators", "exclude_pow", "no_spaces"],
+        default="exclude_pow",
+        help="add space",
+    )
+    parser.add_argument(
+        "--matrix-indent",
+        choices=["aligned", "simple"],
+        default="aligned",
+        help="matrix indentation",
+    )
+    parser.add_argument("--inplace", action="store_true", help="modify file in place")
+
+    args = parser.parse_args()
+
+    indent_modes = {"all_functions": 1, "only_nested_functions": -1, "classic": 0}
+
+    operator_spaces = {"all_operators": 1, "exclude_pow": 0.5, "no_spaces": 0}
+
+    matrix_indentation = {"aligned": 1, "simple": 0}
+
+    formatter = Formatter(
+        args.indent_width,
+        args.separate_blocks,
+        indent_modes.get(args.indent_mode, indent_modes["all_functions"]),
+        operator_spaces.get(args.add_space, operator_spaces["exclude_pow"]),
+        matrix_indentation.get(args.matrix_indent, matrix_indentation["aligned"]),
+    )
+
+    formatter.format_file(
+        args.filename,
+        args.start_line,
+        args.end_line,
+        args.inplace,
+        args.use_tabs,
+        args.use_crlf,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add Octave formatting script

Modified from matlab-formatter-vscode to add GNU Octave support and to adapt
it to cake-autorate's needs (i.e., I added some features like inplace, tabs,
argparse, etc.).

Further, I fixed in which a line like:
`if ...'LOAD', 'REFLECTOR'}) % {'DEBUG', 'INFO', 'SJHAPER'}` would break the
formatter in addition to other more subtle issues.

It is based on https://github.com/affenwiesel/matlab-formatter-vscode commit 43d7224.

For reference on what needs to be modified, see
https://en.wikibooks.org/wiki/MATLAB_Programming/Differences_between_Octave_and_MATLAB


## [Octave] Avoid `end` and use `endif`/`endwhile` consistently

In some parts of the script, there is some usage of `end`.
It doesn't really matter but I prefer for the script to be
more consistent.
