### PR TITLE
Some more bash optimizations

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -76,7 +76,7 @@ sleep_s()
 	# - https://github.com/lynxthecat/cake-autorate/issues/174#issuecomment-1460074498
 
 	local sleep_duration_s=${1} # (seconds, e.g. 0.5, 1 or 1.5)
-	read -r -t "${sleep_duration_s}" -u "${__sleep_fd}" || true
+	read -r -t "${sleep_duration_s}" -u "${__sleep_fd}" || :
 }
 
 sleep_us()


### PR DESCRIPTION
The below changes reduces CPU usage by 0.5% on my X86 machine:

- Switch to using `:` instead of `true` as it is consistently faster in the below benchmark, unsure why as they are both noops:

  + timeout 3 bash -c 'while :; do true; echo y; done'
  + wc -l 1881683
  + timeout 3 bash -c 'while :; do :; echo y; done'
  + wc -l 2152695

- Switch to switch case for the idle/sleep function handling code.

- Remove unneded non-empty string handling check