### PR TITLE
Add ASUSWrt-Merlin support and don't hardcode /root/cake-autorate

### DIFF
--- a/cake-autorate.template
+++ b/cake-autorate.template
@@ -6,7 +6,7 @@ USE_PROCD=1
 
 start_service() {
         procd_open_instance
-        procd_set_param command /root/cake-autorate/launcher.sh
+        procd_set_param command %%SCRIPT_PREFIX%%/launcher.sh
         procd_set_param respawn
         procd_close_instance
 }

--- a/config.primary.sh
+++ b/config.primary.sh
@@ -2,8 +2,9 @@
 
 # *** INSTANCE-SPECIFIC CONFIGURATION OPTIONS ***
 # 
-# cake-autorate will run one instance per config file present in the /root/cake-autorate
-# directory in the form: config.instance.sh. Thus multiple instances of cake-autorate
+# cake-autorate will run one instance per config file present in the directory where
+# cake-autorate is found (typically /root/cake-autorate). The config files must be in
+# the directory in the form: config.instance.sh. Thus multiple instances of cake-autorate
 # can be established by setting up appropriate config files like config.primary.sh and 
 # config.secondary.sh for the respective first and second instances of cake-autorate.
 

--- a/launcher.sh.template
+++ b/launcher.sh.template
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-cake_instances=(/root/cake-autorate/config.*.sh)
+cake_instances=(%%CONFIG_PREFIX%%/config.*.sh)
 cake_instance_pids=()
 
 trap kill_cake_instances INT TERM EXIT
@@ -20,7 +20,7 @@ kill_cake_instances()
 
 for cake_instance in "${cake_instances[@]}"
 do
-	/root/cake-autorate/cake-autorate.sh "${cake_instance}" &
+	%%SCRIPT_PREFIX%%/cake-autorate.sh "${cake_instance}" &
 	cake_instance_pids+=(${!})
 done
 wait

--- a/maint/version_bump.sh
+++ b/maint/version_bump.sh
@@ -24,13 +24,13 @@ then
 	sed -e '/Zep7RkGZ52/a\' -e '\n\n\#\# '"${cur_date}"' - Version '"${version}"'\n\n**Release notes here**' -i CHANGELOG.md
 fi
 ${EDITOR} CHANGELOG.md
-( git add CHANGELOG.md && git commit -sm "Updated CHANGELOG for ${version}"; ) || true
+( git add CHANGELOG.md && git commit -sm "Updated CHANGELOG for ${version}"; ) || :
 
 if sed -E 's/(^cake_autorate_version=\")[^\"]+(\"$)/\1'"${version}"'\2/' -i cake-autorate.sh
 then
 	echo Cake autorate version updated in cake-autorate.sh
 	( git add cake-autorate.sh
-	git commit -sm "Updated cake-autorate.sh version to ${version}"; ) || true
+	git commit -sm "Updated cake-autorate.sh version to ${version}"; ) || :
 fi
 
 if ((is_latest))
@@ -40,5 +40,5 @@ then
 		echo Latest cake autorate version updated in README.md
 	fi
 	( git add README.md
-	git commit -sm "Updated latest version in README.md to ${version}"; ) || true
+	git commit -sm "Updated latest version in README.md to ${version}"; ) || :
 fi


### PR DESCRIPTION
This allows the user to override the default /root/cake-autorate path and should clear the path for a more standard installation.