### PR TITLE
Add remaining Asus Merlin fixes to installer

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,11 +1,11 @@
-# Installing cake-autorate on OpenWrt
+# Installing cake-autorate
 
 **cake-autorate** is a script that minimizes latency by adjusting CAKE
 bandwidth settings based on traffic load and round-trip time
 measurements. See the main [README](./README.md) page for more details
 of the algorithm.
 
-## Installation Steps
+## Installation Steps (OpenWrt)
 
 cake-autorate provides an installation script that installs all the
 required tools. To use it:
@@ -36,21 +36,50 @@ required tools. To use it:
 - The installer script will detect a previous configuration file, and
   ask whether to preserve it.
 
+## Installation Steps (Asus Merlin)
+
+- [SSH into the router](https://github.com/RMerl/asuswrt-merlin.ng/wiki/SSHD)
+
+- Make sure these are installed: entware; bash; iputils-ping; and fping.
+
+- Use the installer script by copying and pasting each of the commands
+  below. The commands retrieve the current version from this repo:
+
+  ```bash
+  wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/cake-autorate/master/setup.sh
+
+  sh /tmp/cake-autorate_setup.sh
+  ```
+
+## Initial Configuration Steps (OpenWrt and Asus Merlin)
+
 - For a fresh install, you will need to undertake the following steps.
 
 - Edit the _config.primary.sh_ script (in the _/root/cake-autorate_
-  directory) using vi or nano to set the configuration parameters
-  below (see comments in _config.primary.sh_ for details).
+  directory for OpenWrt or in the _/jffs/scripts/cake-autorate_ 
+  direction for Asus Merlin) using vi or nano to set the configuration 
+  parameters below (see comments in _config.primary.sh_ for details).
 
   - Change `dl_if` and `ul_if` to match the names of the upload and
-    download interfaces to which CAKE is applied. These can be
-    obtained, for example, by consulting the configured SQM settings
-    in LuCI or by examining the output of `tc qdisc ls`.
+    download interfaces to which CAKE is applied. 
 
     | Variable | Setting                                          |
     | -------: | :----------------------------------------------- |
     |  `dl_if` | Interface that downloads data (often _ifb4-wan_) |
     |  `ul_if` | Interface that uploads (often _wan_)             |
+
+
+  - For OpenWrt installations, these can be obtained, for example, 
+    by consulting the configured SQM settings in LuCi or by examining 
+    the output of `tc qdisc ls`.
+
+  - For Asus Merlin the requisite interfaces can also be obtained
+    by examining the output of `tc qdisc ls`. These are most likely:
+  
+    ```bash
+    dl_if=ifb4eth0 # download interface
+    ul_if=eth0     # upload interface
+    ```
 
   - Choose whether cake-autorate should adjust the shaper rates
     (disable for monitoring only):
@@ -189,7 +218,7 @@ cd /root/cake-autorate     # to the cake-autorate directory
   upload rates as you use the connection.
 - Press ^C to halt the process.
 
-## Install as a service
+## Install as a service (OpenWrt)
 
 You can install cake-autorate as a service that starts up the autorate
 process whenever the router reboots. To do this:
@@ -217,7 +246,18 @@ router to handle selected logging parameters. Consider disabling
 logging or adjusting logging parameters such as 
 `log_file_max_time_mins` or `log_file_max_size_KB` if necessary.
 
-## Preserving cake-autorate files for backup or upgrades
+## Launch on Boot (Asus Merlin)
+
+cake-autorate can be launched on boot by adding an appropriate 
+entry to e.g. post-mount or qos-start -
+see [here](https://github.com/RMerl/asuswrt-merlin.ng/wiki/User-scripts).
+
+
+```bash
+echo /jffs/scripts/cake-autorate/launcher.sh >> /jffs/scripts/qos-start
+```
+
+## Preserving cake-autorate files for backup or upgrades (OpenWrt)
 
 OpenWrt devices can save files across upgrades. Read the
 [Backup and Restore page on the OpenWrt wiki](https://openwrt.org/docs/guide-user/troubleshooting/backup_restore#customize_and_verify)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,19 @@ bandwidth connections such as LTE, Starlink, and cable modems and is
 not generally required for use on connections that have a stable,
 fixed bandwidth.
 
-[CAKE Smart Queue Management (SQM)](https://www.bufferbloat.net/projects/codel/wiki/Cake/)
+[CAKE](https://www.bufferbloat.net/projects/codel/wiki/Cake/)
 is an algorithm that manages the buffering of data being sent/received
-by a device such as an [OpenWrt router](https://openwrt.org) so that
+by a device such as an [OpenWrt router](https://openwrt.org) or an 
+[Asus Merlin router](https://www.asuswrt-merlin.net/) so that
 no more data is queued than is necessary, minimizing the latency
-("bufferbloat") and improving the responsiveness of a network.
+("bufferbloat") and improving the responsiveness of a network. 
+An instance of cake on an interface is set up with a certain bandwidth.
+Although this bandwidth can be changed, the cake algorithm itself has 
+no reliable means to adjust the bandwidth on the fly. **cake-autorate**
+bridges this gap.
+
+**cake-autorate** presently supports installation on devices running 
+OpenWrt and Asus Merlin.
 
 ### Status
 
@@ -111,7 +119,7 @@ always testing for the true maximum as explained above).
 The baseline bandwidth is likely optimally either the minimum
 bandwidth or somewhere close thereto (e.g. the compromise bandwidth).
 
-## Installation on OpenWrt
+## Installation on OpenWrt or Asus Merlin
 
 Read the installation instructions in the separate
 [INSTALLATION](./INSTALLATION.md) page.

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ main() {
 	set -eu
 
 	# Setup dependencies to check for
-	DEPENDENCIES="jsonfilter wget tar grep"
+	DEPENDENCIES="jsonfilter wget tar grep bash"
 
 	# Set up remote locations and branch
 	REPOSITORY=${CAKE_AUTORATE_REPO:-${1-lynxthecat/cake-autorate}}
@@ -80,16 +80,6 @@ main() {
 		fi
 	done
 	[ "${exit_now}" -ge 1 ] && exit "${exit_now}"
-
-	# Retrieve required packages if not present
-	# shellcheck disable=SC2312
-	if [ "$(opkg list-installed | grep -Ec '^(bash|fping) ')" -ne 2 ]
-	then
-		printf "Running opkg update to update package lists:\n"
-		opkg update
-		printf "Installing bash and fping packages:\n"
-		opkg install bash fping
-	fi
 
 	# Create the cake-autorate directory if it does not exist
 	mkdir -p "${SCRIPT_PREFIX}" "${CONFIG_PREFIX}"
@@ -171,9 +161,12 @@ main() {
 	sed -e "s|%%SCRIPT_PREFIX%%|${SCRIPT_PREFIX}|g" -e "s|%%CONFIG_PREFIX%%|${CONFIG_PREFIX}|g" \
 		"${tmp}/launcher.sh.template" > "${SCRIPT_PREFIX}/launcher.sh"
 
-	# Also generate the service file from cake-autorate.template but DO NOT ACTIVATE IT
-	sed "s|%%SCRIPT_PREFIX%%|${SCRIPT_PREFIX}|g" "${tmp}/cake-autorate.template" > /etc/init.d/cake-autorate
-	chmod +x /etc/init.d/cake-autorate
+	# Also for OpenWrt generate the service file from cake-autorate.template but DO NOT ACTIVATE IT
+	if [ "${MY_OS}" = "openwrt" ]
+	then
+		sed "s|%%SCRIPT_PREFIX%%|${SCRIPT_PREFIX}|g" "${tmp}/cake-autorate.template" > /etc/init.d/cake-autorate
+		chmod +x /etc/init.d/cake-autorate
+	fi
 
 	# Get version and generate a file containing version information
 	cd "${SCRIPT_PREFIX}"
@@ -190,8 +183,20 @@ main() {
 	printf '\n%s\n\n' "${version} successfully installed, but not yet running"
 	printf '%s\n' "Start the software manually with:"
 	printf '%s\n' "   cd ${SCRIPT_PREFIX}; ./cake-autorate.sh"
-	printf '%s\n' "Run as a service with:"
-	printf '%s\n\n' "   service cake-autorate enable; service cake-autorate start"
+
+	case "${MY_OS}" in
+
+		"openwrt")
+			printf '%s\n' "Run as a service with:"
+			printf '%s\n\n' "   service cake-autorate enable; service cake-autorate start"
+			;;
+		"asuswrt")
+			printf '%s\n' "Launch script on boot with:"
+			printf '%s\n\n' "   echo ${SCRIPT_PREFIX}/launcher.sh >> /jffs/scripts/post-mount"
+			;;
+		*)
+			;;
+	esac
 }
 
 # Now that we are sure all code is loaded, we could execute the function

--- a/setup.sh
+++ b/setup.sh
@@ -85,6 +85,12 @@ main() {
 	done
 	[ "${exit_now}" -ge 1 ] && exit "${exit_now}"
 
+	if ! type "fping" >/dev/null 2>&1; then
+		printf "Warning, fping is required by default, but it is not installed.\n"
+		pritnf "So cake-autorate will not run with default settings.\n"
+		printf "Either install fping or ensure that one of the other supported ping binaries is installed and selected in the config(s).\n"
+	fi
+
 	# Create the cake-autorate directory if it does not exist
 	mkdir -p "${SCRIPT_PREFIX}" "${CONFIG_PREFIX}"
 

--- a/setup.sh
+++ b/setup.sh
@@ -32,9 +32,13 @@ main() {
 
 	# Check if OS is OpenWRT or derivative
 	unset ID_LIKE
-	# We do `set +/-e` here because in some Busybox sh versions
-	# `. /not_found || true` doesn't do anything
-	set +e; . /etc/os-release 2>/dev/null; set -e
+
+	# The following formulations seem to be problematic for some sh versions:
+	# - `. /not_found || true`
+	# - set +e; . /etc/os-release 2>/dev/null; set -e
+	# but this seems to work OK:
+	[ -e "/etc/os-release" ] && . /etc/os-release
+
 	for x in ${ID_LIKE:-}
 	do
 		if [ "${x}" = "openwrt" ]

--- a/setup.sh
+++ b/setup.sh
@@ -164,6 +164,7 @@ main() {
 	# Generate a launcher.sh file from the launcher.sh.template file
 	sed -e "s|%%SCRIPT_PREFIX%%|${SCRIPT_PREFIX}|g" -e "s|%%CONFIG_PREFIX%%|${CONFIG_PREFIX}|g" \
 		"${tmp}/launcher.sh.template" > "${SCRIPT_PREFIX}/launcher.sh"
+	chmod +x "${SCRIPT_PREFIX}/launcher.sh"
 
 	# Also for OpenWrt generate the service file from cake-autorate.template but DO NOT ACTIVATE IT
 	if [ "${MY_OS}" = "openwrt" ]

--- a/setup.sh
+++ b/setup.sh
@@ -203,7 +203,7 @@ main() {
 			;;
 		"asuswrt")
 			printf '%s\n' "Launch script on boot with:"
-			printf '%s\n\n' "   echo ${SCRIPT_PREFIX}/launcher.sh >> /jffs/scripts/post-mount"
+			printf '%s\n\n' "   echo ${SCRIPT_PREFIX}/launcher.sh >> /jffs/scripts/qos-start"
 			;;
 		*)
 			;;


### PR DESCRIPTION
@LiveWire1968 any chance you could test the latest code on this asus-merlin branch and we'll add any necessary remaining fixes?

I think(?) the installation instructions should be something like:

Make sure these are installed: entware; bash; iputils-ping; and fping.

And then run:

```
wget https://raw.githubusercontent.com/lynxthecat/cake-autorate/asus-merlin/setup.sh
chmod +x ./setup.sh
./setup.sh lynxthecat/cake-autorate asus-merlin
```


And then edit the config file to specify the correct interfaces:

```
dl_if=ifb4eth0 # download interface
ul_if=eth0     # upload interface
```
and bandwidths (change according to your connection specifics):

```
min_dl_shaper_rate_kbps=5000   # minimum bandwidth for download (Kbit/s)
base_dl_shaper_rate_kbps=60000 # steady state bandwidth for download (Kbit/s)
max_dl_shaper_rate_kbps=100000 # maximum bandwidth for download (Kbit/s)

min_ul_shaper_rate_kbps=20000  # minimum bandwidth for upload (Kbit/s)
base_ul_shaper_rate_kbps=30000 # steady state bandwidth for upload (KBit/s)
max_ul_shaper_rate_kbps=35000  # maximum bandwidth for upload (Kbit/s)[/CODE]
```

And also enable logging:

```
output_summary_stats=1    # enable (1) or disable (0) output monitoring lines showing summary stats
```

And then try running manually:

```
./cake-autorate.sh
```

Does it work?