### PR TITLE
Scale rate increases as OWDs near delay threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ more about cake-autorate. This is the history of changes.
 
 <!-- Zep7RkGZ52|NEW ENTRY MARKER, DO NOT REMOVE -->
 
+## 2024-06-17 - Version 3.3.0
+
+- Improve shaper rate controller by reducing the shaper rate increases
+  on high load as the average OWD delta approaches the delay threshold.
+  For this purpose, a new lower average OWD delta threshold has been 
+  introduced beyond which the shaper rate increases are reduced from
+  a maximum increase rate at the threshold to a minimum increase rate
+  at the delay treshold.
+
+- Rename the various thresholds in the light of the new lower average
+  OWD threshold for readability and consistency and add appropriate 
+  documentation for their use.
+
 ## 2024-05-18 - Version 3.2.1
 
 - This release fixes setup.sh on OpenWRT and some documentation

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -130,15 +130,19 @@ be (and is ideally) fine-tuned.
   cake-autorate has been installed, you may wish to override some of
   these by providing corresponding entries inside _config.primary.sh_.
 
-  - For example, to set a different `dl_owd_delta_thr_ms`, then add a
-    line to the config file _config.primary.sh_ like:
+  - For example, to set a different `dl_owd_delta_delay_thr_ms`, then 
+    add a line to the config file _config.primary.sh_ like:
 
     ```bash
-    dl_owd_delta_thr_ms=100
+    dl_owd_delta_delay_thr_ms=100.0
     ```
 
 - Users are encouraged to look at _defaults.sh_, which documents the
   many configurable parameters of cake-autorate.
+
+- The type of variable: integer, float, string used in any config file
+  must reflect the same type used in _defaults.sh_, and otherwise 
+  cake-autorate will throw an error on startup.
 
   ## Delay thresholds
 
@@ -147,20 +151,36 @@ be (and is ideally) fine-tuned.
 
     |                  Variable | Setting                                                                                                      |
     | ------------------------: | :----------------------------------------------------------------------------------------------------------- |
-    |     `dl_owd_delta_thr_ms` | extent of download OWD increase to classify as a delay                                                       |
-    |     `ul_owd_delta_thr_ms` | extent of upload OWD increase to classify as a delay                                                         |
-    | `dl_avg_owd_delta_thr_ms` | average download OWD threshold across reflectors at which maximum downward shaper rate adjustment is applied |
-    | `ul_avg_owd_delta_thr_ms` | average upload OWD threshold across reflectors at which maximum downward shaper rate adjustment is applied   |
+    |                  `dl_owd_delta_delay_thr_ms` | extent of download OWD increase to classify as a delay                                                       |
+    |                  `ul_owd_delta_delay_thr_ms` | extent of upload OWD increase to classify as a delay                                                         |
+    |      `dl_avg_owd_delta_max_adjust_up_thr_ms` | average download OWD threshold across reflectors at which maximum upward shaper rate adjustment is applied   |
+    |      `ul_avg_owd_delta_max_adjust_up_thr_ms` | average upload OWD threshold across reflectors at which maximum upward shaper rate adjustment is applied     |
+    |    `dl_avg_owd_delta_max_adjust_down_thr_ms` | average download OWD threshold across reflectors at which maximum downward shaper rate adjustment is applied |
+    |    `ul_avg_owd_delta_max_adjust_down_thr_ms` | average upload OWD threshold across reflectors at which maximum downward shaper rate adjustment is applied   |
+
 
     An OWD measurement to an individual reflector that exceeds
-    `xl_owd_delta_thr_ms` from its baseline is classified as a delay.
-    Bufferbloat is detected when there are `bufferbloat_detection_thr`
-    delays out of the last`bufferbloat_detection_window` reflector
-    responses. Upon bufferbloat detection, the extent of the average
-    OWD delta taken across the reflectors governs how much the shaper
-    rate is adjusted down (scaled by average delta OWD /
-    `xl_avg_owd_delta_thr_ms`).
+    `xl_owd_delta_delay_thr_ms` from its baseline is classified as a 
+    delay. Bufferbloat is detected when there are 
+    `bufferbloat_detection_thr` delays out of the last
+    `bufferbloat_detection_window` reflector responses. 
 
+    Prior to bufferbloat detection, the extent of the average OWD
+    delta taken across the reflectors governs how much the shaper
+    rate is adjusted up. The adjustment is scaled linearly from 
+    `shaper_rate_max_adjust_up_load_high` (at or below
+    xl_avg_owd_delta_max_adjust_up_thr_ms)
+    to `shaper_rate_min_adjust_up_load_high` (at 
+    xl_owd_delta_thr_ms).
+
+    Upon bufferbloat detection, the extent of the average OWD delta 
+    taken across the reflectors governs how much the shaper rate is 
+    adjusted down. The adjustment is scaled linearly from 
+    `shaper_rate_min_adjust_down_bufferbloat` (at
+    xl_owd_delta_thr_ms) 
+    to `shaper_rate_min_adjust_down_bufferbloat` (at or above
+    xl_avg_owd_delta_max_adjust_down_thr_ms).
+    
     Avoiding bufferbloat requires throttling the connection, and thus
     there is a trade-off between bandwidth and latency.
 

--- a/defaults.sh
+++ b/defaults.sh
@@ -76,15 +76,23 @@ randomize_reflectors=1 # enable (1) or disable (0) randomization of reflectors o
 no_pingers=6 # number of pingers to maintain
 reflector_ping_interval_s=0.3 # (seconds, e.g. 0.2s or 2s)
 
+# average owd delta threshold in ms up to which the maximum adjust_up_load_high is applied to the shaper rate adjustment
+# for average owd deltas between avg_owd_delta_max_adjust_up_thr_ms and owd_delta_thr_ms, the adjustment is scaled linearly
+# from max_adjust_up_load_high (at avg_owd_delta_max_adjust_up_thr_ms) to min_adjust_up_load_high (at owd_delta_thr_ms)
+dl_avg_owd_delta_max_adjust_up_thr_ms=10.0 # (milliseconds)
+ul_avg_owd_delta_max_adjust_up_thr_ms=10.0 # (milliseconds)
+
 # owd delta threshold in ms is the extent of OWD increase to classify as a delay
 # these are automatically adjusted based on maximum on the wire packet size
 # (adjustment significant at sub 12Mbit/s rates, else negligible)
-dl_owd_delta_thr_ms=30.0 # (milliseconds)
-ul_owd_delta_thr_ms=30.0 # (milliseconds)
+dl_owd_delta_delay_thr_ms=30.0 # (milliseconds)
+ul_owd_delta_delay_thr_ms=30.0 # (milliseconds)
 
-# average owd delta threshold in ms at which maximum adjust_down_bufferbloat is applied
-dl_avg_owd_delta_thr_ms=60.0 # (milliseconds)
-ul_avg_owd_delta_thr_ms=60.0 # (milliseconds)
+# average owd delta threshold in ms beyond which the maximum adjust_down_bufferbloat is applied to the shaper rate adjustment
+# for average owd deltas between owd_delta_thr_ms and avg_owd_delta_max_adjust_up_thr_ms, the adjustment is scaled linearly
+# from min_adjust_down_bufferbloat (at owd_delta_thr_ms) to min_adjust_up_load_high (at avg_owd_delta_max_adjust_down_thr_ms)
+dl_avg_owd_delta_max_adjust_down_thr_ms=60.0 # (milliseconds)
+ul_avg_owd_delta_max_adjust_down_thr_ms=60.0 # (milliseconds)
 
 # Set either of the below to 0 to adjust one direction only
 # or alternatively set both to 0 to simply use cake-autorate to monitor a connection
@@ -171,7 +179,8 @@ alpha_delta_ewma=0.095
 # otherwise shaper rate is adjusted up on load high, and down on load idle or low
 shaper_rate_min_adjust_down_bufferbloat=0.99    # how rapidly to reduce shaper rate upon detection of bufferbloat (min reduction)
 shaper_rate_max_adjust_down_bufferbloat=0.75	# how rapidly to reduce shaper rate upon detection of bufferbloat (max reduction)
-shaper_rate_adjust_up_load_high=1.04		# how rapidly to increase shaper rate upon high load detected
+shaper_rate_min_adjust_up_load_high=1.0		# how rapidly to increase shaper rate upon high load detected (min increase)
+shaper_rate_max_adjust_up_load_high=1.04	# how rapidly to increase shaper rate upon high load detected (max increase)
 shaper_rate_adjust_down_load_low=0.99		# how rapidly to return down to base shaper rate upon idle or low load detected
 shaper_rate_adjust_up_load_low=1.01		# how rapidly to return up to base shaper rate upon idle or low load detected
 


### PR DESCRIPTION
Improve controller by easing off on the rate of shaper rate increase as the average OWD delay crosses a new threshold and approaches the delta delay threshold