### PR TITLE
Mention that apk may be required if opkg is not found

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -24,11 +24,21 @@ required tools. To use it:
 
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
 
-- Install bash and fping by running:
+- Ensure `bash` and `fping` are installed.
+
+  On most OpenWrt installations, you can install them by running:
 
   ```bash
   opkg update
   opkg install bash fping
+  ```
+
+  If the `opkg` command is not found, you may need to use `apk`
+  instead:
+
+  ```bash
+  apk update
+  apk add bash fping
   ```
 
 - Use the installer script by copying and pasting each of the commands


### PR DESCRIPTION
Experimental SNAPSHOT builds switched USE_APK to y recently.

Fixes: https://github.com/lynxthecat/cake-autorate/issues/317