### PR TITLE
Mention that apk may be required if opkg is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ more about cake-autorate. This is the history of changes.
 
 <!-- Zep7RkGZ52|NEW ENTRY MARKER, DO NOT REMOVE -->
 
+## 2024-11-27 - Version 3.2.2
+
+- This release updates the documentation to mention that the `apk`
+  command should be used to install dependencies if `opkg` is not
+  found.
+
 ## 2024-05-18 - Version 3.2.1
 
 - This release fixes setup.sh on OpenWRT and some documentation

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -24,11 +24,21 @@ required tools. To use it:
 
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
 
-- Install bash and fping by running:
+- Ensure `bash` and `fping` are installed.
+
+  On most OpenWrt installations, you can install them by running:
 
   ```bash
   opkg update
   opkg install bash fping
+  ```
+
+  If the `opkg` command is not found, you may need to use `apk`
+  instead:
+
+  ```bash
+  apk update
+  apk add bash fping
   ```
 
 - Use the installer script by copying and pasting each of the commands


### PR DESCRIPTION
Experimental SNAPSHOT builds switched USE_APK to y recently.

Fixes: https://github.com/lynxthecat/cake-autorate/issues/317