### PR TITLE
Minimize irtt restart delay

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -535,6 +535,10 @@ start_pinger()
 									fflush("")
 								}
 							}
+							else if (/WaitForPackets/)
+							{
+								break
+							}
 						}
 
 						close(irtt_cmd)


### PR DESCRIPTION
We should stop parsing output from `irtt` and immediately respawn it once it reaches its waiting for final packets phase. This prevents us from waiting for statistics generation which is irrelevant to the use-case of `cake-autorate`, reducing the gap in data between restarts when the duration elapses.

During this 30 second test run, `irtt` waited 267.9ms before generating its final statistics. For a pinger running every 50ms, that's a long time to go without providing data.

```bash
seq=595 rtt=47.26ms rd=33.72ms sd=13.54ms ipdv=438µs
[x.x.x.x:2112] [WaitForPackets] waiting 267.9ms for final packets
seq=596 rtt=47.56ms rd=33.64ms sd=13.92ms ipdv=305µs
```
This change adds a check for the `[WaitForPackets]` message. As soon as we see it, we break the inner loop and restart `irtt`.

The loss of a single data point seems inconsequential compared to eliminating the current wait time, which by default is 3x the max RTT and can be up to 4 seconds if there's no response.