### PR TITLE
Support generic Linux with OpenRC (Alpine, Gentoo, Artix, …)

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -21,3 +21,14 @@ enable=all
 
 # Allow shellcheck to access arbitrary files
 external-sources=true
+
+# Prefer ${var} braces (opt-in style; the codebase mixes both intentionally).
+disable=SC2250
+
+# $ / ${ } around arithmetic operands is unnecessary (cosmetic).
+disable=SC2004
+
+# Intentional array->string joins (the CPU-stat lines reuse the array name as
+# a scalar via ${arr[*]} then ${scalar// /...}); not bugs.
+disable=SC2178
+disable=SC2128

--- a/INSTALLATION-linux-openrc.md
+++ b/INSTALLATION-linux-openrc.md
@@ -1,0 +1,71 @@
+# Installation on a generic Linux router with OpenRC
+
+cake-autorate was written for OpenWrt, where the [SQM](https://openwrt.org/docs/guide-user/network/traffic-shaping/sqm)
+package creates the CAKE qdiscs and cake-autorate only *adjusts* their bandwidth.
+
+This adds first-class support for a **generic Linux router running OpenRC**
+(Alpine, Gentoo, Artix, …), which has no SQM package: a small helper,
+`sqm-setup.sh`, brings the CAKE qdiscs up, and an OpenRC service wires it all
+together. The core (`cake-autorate.sh`) is unchanged.
+
+## Requirements
+
+- `bash`, `iproute2` (`tc`), `fping`
+- kernel modules `sch_cake` and `ifb`
+- OpenRC (`rc-update`, `rc-service`)
+
+On Alpine: `apk add bash iproute2 fping`.
+
+## Install
+
+```sh
+sh -c "$(wget -qO- https://raw.githubusercontent.com/lynxthecat/cake-autorate/master/setup.sh)"
+```
+
+`setup.sh` detects OpenRC and installs into `/root/cake-autorate`, generating
+(but **not** enabling) an OpenRC service at `/etc/init.d/cake-autorate`.
+
+## Configure
+
+Edit `/root/cake-autorate/config.primary.sh`:
+
+| variable | meaning | example |
+| --- | --- | --- |
+| `ul_if` | WAN interface (upload egress) | `eth0` |
+| `dl_if` | IFB device for ingress shaping (created by `sqm-setup.sh`) | `ifb-eth0` |
+| `min_/base_/max_dl_shaper_rate_kbps` | download rate bounds | — |
+| `min_/base_/max_ul_shaper_rate_kbps` | upload rate bounds | — |
+
+Optional, to pass extra CAKE keywords per direction. The defaults give full
+per-host fairness on a NAT router (like OpenWrt SQM) — `nat` resolves the inside
+hosts and `dual-srchost`/`dual-dsthost` share bandwidth per LAN host, so no
+single host can starve the others:
+
+| variable | default |
+| --- | --- |
+| `sqm_ul_cake_opts` | `nat dual-srchost` |
+| `sqm_dl_cake_opts` | `nat dual-dsthost ingress` |
+
+## Run
+
+```sh
+rc-update add cake-autorate default
+rc-service cake-autorate start
+```
+
+The service runs `sqm-setup.sh start` (creates the qdiscs), then the launcher
+runs the cake-autorate instance(s). `rc-service cake-autorate stop` tears the
+qdiscs back down.
+
+## How it works
+
+`sqm-setup.sh` reproduces, on a generic Linux host, what SQM does on OpenWrt:
+
+- CAKE on `ul_if` egress (upload shaping);
+- an IFB (`dl_if`) fed by a `tc` ingress redirect from `ul_if`, with CAKE on the
+  IFB (download shaping).
+
+It reads `ul_if`/`dl_if` and the base rates from the **same** instance config
+that `cake-autorate.sh` uses, so there is a single source of truth. cake-autorate
+then adjusts the CAKE bandwidth in real time — ideal for highly variable links
+(Starlink, LTE/5G).

--- a/cake-autorate.openrc.template
+++ b/cake-autorate.openrc.template
@@ -10,8 +10,9 @@
 
 # Some OpenRC setups run services with a minimal PATH that omits /sbin, where
 # tc/ip/modprobe live. Both sqm-setup.sh (start_pre) and the launcher's CAKE
-# adjustments need them, so make PATH explicit for the whole service.
-export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+# adjustments need them. APPEND (do not overwrite) so OpenRC's own helpers
+# (ebegin, mountinfo, service_*) on the original PATH stay reachable.
+export PATH="${PATH}:/usr/sbin:/sbin"
 
 description="cake-autorate — adaptive CAKE bandwidth (with SQM bring-up)"
 

--- a/cake-autorate.openrc.template
+++ b/cake-autorate.openrc.template
@@ -1,0 +1,33 @@
+#!/sbin/openrc-run
+# shellcheck shell=sh
+# shellcheck disable=SC2034  # description/command/pidfile are consumed by openrc-run
+
+# OpenRC service for cake-autorate on a generic Linux host (Alpine, Gentoo,
+# Artix, …). Unlike OpenWrt — where the SQM package creates the CAKE qdiscs —
+# here start_pre brings the qdiscs up via sqm-setup.sh, the launcher then runs the
+# cake-autorate instance(s) that adjust the bandwidth, and stop_post tears the
+# qdiscs back down.
+
+# Some OpenRC setups run services with a minimal PATH that omits /sbin, where
+# tc/ip/modprobe live. Both sqm-setup.sh (start_pre) and the launcher's CAKE
+# adjustments need them, so make PATH explicit for the whole service.
+export PATH="/usr/sbin:/usr/bin:/sbin:/bin"
+
+description="cake-autorate — adaptive CAKE bandwidth (with SQM bring-up)"
+
+command="%%SCRIPT_PREFIX%%/launcher.sh"
+command_background=true
+pidfile="/run/cake-autorate.pid"
+
+depend() {
+	need net
+	after firewall
+}
+
+start_pre() {
+	"%%SCRIPT_PREFIX%%/sqm-setup.sh" start
+}
+
+stop_post() {
+	"%%SCRIPT_PREFIX%%/sqm-setup.sh" stop
+}

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -497,6 +497,7 @@ start_pinger()
 		irtt)
 			sleep_until_next_pinger_time_slot "${pinger}"
 
+			# shellcheck disable=SC2155  # the subshell status (echo $!) is intentionally unused
 			local pinger_pid=$( (
 				set -m
 				${ping_prefix_string} gawk -v extra_args="${ping_extra_args}" -v interval_s="${reflector_ping_interval_s}" -v duration_m="${irtt_session_duration_m}" -v reflector="${reflectors[$pinger]}" -f <(cat <<-'EOT'
@@ -574,7 +575,7 @@ start_pinger()
 			sleep_until_next_pinger_time_slot "${pinger}"
 			${ping_prefix_string} ping ${ping_extra_args} -D -i "${reflector_ping_interval_s}" "${reflectors[pinger]}" 2> /dev/null >&"${main_fd}" &
 			pinger_pids[pinger]=${!}
-			proc_pids["ping_${pinger}_pinger"]=${pinger_pids[0]}
+			proc_pids["ping_${pinger}_pinger"]=${pinger_pids[pinger]}
 			;;
 		*)
 			log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
@@ -693,15 +694,16 @@ replace_pinger_reflector()
 		# shellcheck disable=SC2206
 		reflectors+=(${bad_reflector})
 		# reset array indices
+		# shellcheck disable=SC2206
 		reflectors=(${reflectors[@]})
 		if ((retain_reflector_stats==0))
 		then
 			log_msg "DEBUG" "Discarding reflector stats associated with ${bad_reflector}"
-			unset dl_owd_baselines_us[${bad_reflector}]
-			unset ul_owd_baselines_us[${bad_reflector}]
-			unset dl_owd_delta_ewmas_us[${bad_reflector}]
-			unset ul_owd_delta_ewmas_us[${bad_reflector}]
-			unset last_timestamp_reflectors_us[${bad_reflector}]
+			unset "dl_owd_baselines_us[${bad_reflector}]"
+			unset "ul_owd_baselines_us[${bad_reflector}]"
+			unset "dl_owd_delta_ewmas_us[${bad_reflector}]"
+			unset "ul_owd_delta_ewmas_us[${bad_reflector}]"
+			unset "last_timestamp_reflectors_us[${bad_reflector}]"
 		else
 			log_msg "DEBUG" "Retaining reflector stats associated with: ${bad_reflector}"
 		fi
@@ -1036,7 +1038,7 @@ esac
 cpu_idx=0
 while :
 do
-	read -r cpu_id rem
+	read -r cpu_id _
 	case ${cpu_id} in
 		cpu*)
 			cpu_ids[cpu_idx]=${cpu_id^^}
@@ -1047,7 +1049,7 @@ do
 			;;
 	esac
 done</proc/stat
-cpu_ids="${cpu_ids[@]}"
+cpu_ids="${cpu_ids[*]}"
 ((cpu_cores=cpu_idx-1))
 log_msg "DEBUG" "Detected ${cpu_cores} CPU cores."
 mapfile -t cpu_usage < <(for ((i=0; i <= cpu_cores; i++)); do echo 0; done)
@@ -1716,7 +1718,7 @@ do
 						read -r -a cpu_stats
 						if (( output_cpu_stats ))
 						then
-							cpu_stats_vals=${cpu_stats[@]:1}
+							cpu_stats_vals=${cpu_stats[*]:1}
 							((
 								cpu_sum=${cpu_stats_vals// /+},
 								cpu_delta=cpu_sum-last_cpu_sum[cpu_idx],
@@ -1728,13 +1730,13 @@ do
 						fi
 						if (( output_cpu_raw_stats ))
 						then
-							cpu_raw_stats="${cpu_stats[@]}"	cpu_raw_stats="${stats_read_time_us}; ${cpu_raw_stats// /; }"
+							cpu_raw_stats="${cpu_stats[*]}"	cpu_raw_stats="${stats_read_time_us}; ${cpu_raw_stats// /; }"
 							log_msg "CPU_RAW" "${cpu_raw_stats}"
 						fi
 					done</proc/stat
 					if (( output_cpu_stats ))
 					then
-						cpu_stats="${cpu_usage[@]}" cpu_stats="${stats_read_time_us}; ${cpu_stats// /; }"
+						cpu_stats="${cpu_usage[*]}" cpu_stats="${stats_read_time_us}; ${cpu_stats// /; }"
 						log_msg "CPU" "${cpu_stats}"
 					fi
 					t_last_cpu_usage_check_us=${t_start_us}

--- a/cake-autorate.template
+++ b/cake-autorate.template
@@ -1,4 +1,5 @@
 #!/bin/sh /etc/rc.common
+# shellcheck disable=SC2034
 
 START=97
 STOP=4

--- a/config.primary.sh
+++ b/config.primary.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 # *** INSTANCE-SPECIFIC CONFIGURATION OPTIONS ***
 # 

--- a/defaults.sh
+++ b/defaults.sh
@@ -48,6 +48,12 @@ log_file_path_override=""
 dl_if=ifb-wan # download interface
 ul_if=wan     # upload interface
 
+# CAKE option strings for the generic-Linux sqm-setup.sh helper, which creates
+# the qdiscs that cake-autorate then adjusts. Declared here so they are valid
+# config keys (sqm-setup.sh reads these, or a per-instance override).
+sqm_dl_cake_opts="nat dual-dsthost ingress"
+sqm_ul_cake_opts="nat dual-srchost"
+
 # pinger method selection can be any of:
 # fping - round robin pinging (RTTs)
 # fping-ts - round robin pinging using ICMP type 13 (OWDs)

--- a/defaults.sh
+++ b/defaults.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 # defaults.sh -- default configuration values for cake-autorate.sh
 #

--- a/launcher.sh.template
+++ b/launcher.sh.template
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
+
+# An unmatched glob must expand to nothing (not the literal pattern), so a
+# missing config set yields an empty array instead of a bogus instance path.
+shopt -s nullglob
 
 cake_instances=()
 if command -v uci >/dev/null 2>&1 && uci show cake-autorate >/dev/null 2>&1
@@ -20,6 +25,13 @@ then
 else
 	cake_instances=(%%CONFIG_PREFIX%%/config.*.sh)
 fi
+
+if [[ ${#cake_instances[@]} -eq 0 ]]
+then
+	printf '%s\n' "cake-autorate: no config files found in %%CONFIG_PREFIX%%" >&2
+	exit 1
+fi
+
 cake_instance_pids=()
 
 trap kill_cake_instances INT TERM EXIT

--- a/mqtt-publisher.sh
+++ b/mqtt-publisher.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155
 
 CPU_CORES=$(grep -c '^processor' /proc/cpuinfo) || { echo "ERROR: failed to detect CPU core count from /proc/cpuinfo" >&2; exit 1; }
 

--- a/mqtt-publisher.template
+++ b/mqtt-publisher.template
@@ -1,4 +1,5 @@
 #!/bin/sh /etc/rc.common
+# shellcheck disable=SC2034
 
 START=98
 STOP=10

--- a/setup.sh
+++ b/setup.sh
@@ -32,7 +32,7 @@ main() {
 	set -eu
 
 	# Setup dependencies to check for
-	DEPENDENCIES="jsonfilter tar grep cmp mktemp bash"
+	DEPENDENCIES="tar grep sed cmp mktemp bash"
 
 	# Set up remote locations and branch
 	BRANCH="${CAKE_AUTORATE_BRANCH:-${2-master}}"
@@ -76,10 +76,20 @@ main() {
 		[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/jffs/configs/cake-autorate
 	fi
 
-	# If we are not running on OpenWRT or ASUSWRT-Merlin, exit
+	# Check for a generic Linux host with OpenRC (Alpine, Gentoo, Artix, …).
+	# These have no SQM package, so cake-autorate brings the CAKE qdiscs up
+	# itself via sqm-setup.sh, wired into the OpenRC service's start_pre/stop_post.
+	if [ "${MY_OS}" = "unknown" ] && command -v rc-update >/dev/null 2>&1 && command -v rc-service >/dev/null 2>&1
+	then
+		MY_OS=linux-openrc
+		[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/root/cake-autorate
+		[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/root/cake-autorate
+	fi
+
+	# If we are not running on a supported OS, exit
 	if [ "${MY_OS}" = "unknown" ]
 	then
-		printf "This script requires OpenWrt or ASUSWRT-Merlin\n" >&2
+		printf "This script requires OpenWrt, ASUSWRT-Merlin, or a Linux host with OpenRC\n" >&2
 		return 1
 	fi
 
@@ -125,10 +135,15 @@ main() {
 	# Create the cake-autorate directory if it does not exist
 	mkdir -p "${SCRIPT_PREFIX}" "${CONFIG_PREFIX}"
 
-	# Get the latest commit to download
-	[ -z "${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT:-}" ] && \
-		commit=$(download_url "${API_URL}" | jsonfilter -e @.sha) || \
+	# Get the latest commit to download. Parse the GitHub API JSON portably with
+	# grep/sed (jsonfilter is OpenWrt-only), so this works on any Linux too. The
+	# explicit if/else keeps set -e semantics intact (no command-substitution in
+	# an || chain).
+	if [ -n "${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT:-}" ]; then
 		commit="${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT}"
+	else
+		commit=$(download_url "${API_URL}" | grep -m1 -oE '"sha"[[:space:]]*:[[:space:]]*"[0-9a-f]+"' | sed -E 's/.*"([0-9a-f]+)".*/\1/')
+	fi
 	if [ -z "${commit:-}" ];
 	then
 		printf >&2 "Invalid operation occurred, commit variable should not be empty"
@@ -174,7 +189,6 @@ main() {
 				exec "${tmp}/setup.sh" "${REPOSITORY}" "${BRANCH}"
 		else
 			printf "Self-replacing not fully supported. Restarting with the new setup.sh...\n"
-			rm -rf "${tmp}"
 			exec "${tmp}/setup.sh" "${REPOSITORY}" "${BRANCH}"
 		fi
 
@@ -219,7 +233,7 @@ main() {
 	# move the program files to the cake-autorate directory
 	# scripts that need to be executable are already marked as such in the tarball
 	cd "${SCRIPT_PREFIX}"
-	files="cake-autorate.sh defaults.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh"
+	files="cake-autorate.sh defaults.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh sqm-setup.sh"
 	for file in ${files}
 	do
 		mv "${tmp}/${file}" "${file}"
@@ -237,6 +251,14 @@ main() {
 		chmod +x /etc/init.d/cake-autorate
 		sed "s|%%SCRIPT_PREFIX%%|${SCRIPT_PREFIX}|g" "${tmp}/mqtt-publisher.template" > /etc/init.d/mqtt-publisher
 		chmod +x /etc/init.d/mqtt-publisher
+	fi
+
+	# For generic Linux with OpenRC, generate the init service (SQM bring-up +
+	# launcher) but DO NOT ACTIVATE it — the user enables it explicitly below.
+	if [ "${MY_OS}" = "linux-openrc" ]
+	then
+		sed "s|%%SCRIPT_PREFIX%%|${SCRIPT_PREFIX}|g" "${tmp}/cake-autorate.openrc.template" > /etc/init.d/cake-autorate
+		chmod +x /etc/init.d/cake-autorate
 	fi
 
 	# Get version and generate a file containing version information
@@ -266,6 +288,12 @@ main() {
 			printf '%s\n' "   echo ${SCRIPT_PREFIX}/launcher.sh > /opt/etc/init.d/S99cake-autorate"
 			printf '%s\n' "   chmod +x /opt/etc/init.d/S99cake-autorate"
 			printf '%s\n\n' "See also: https://github.com/RMerl/asuswrt-merlin.ng/wiki/User-scripts"
+			;;
+		"linux-openrc")
+			printf '%s\n' "Set the WAN interface (ul_if), the IFB (dl_if) and the shaper rates in"
+			printf '%s\n' "   ${CONFIG_PREFIX}/config.primary.sh"
+			printf '%s\n' "then enable and start the service (sqm-setup.sh brings the CAKE qdiscs up):"
+			printf '%s\n\n' "   rc-update add cake-autorate default; rc-service cake-autorate start"
 			;;
 		*)
 			;;

--- a/sqm-setup.sh
+++ b/sqm-setup.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# sqm-setup.sh — minimal CAKE bring-up for GENERIC LINUX hosts.
+#
+# On OpenWrt the CAKE qdiscs are created by the SQM package and cake-autorate
+# only *adjusts* their bandwidth. A generic Linux router has no SQM, so this
+# helper creates exactly the qdiscs that cake-autorate then adjusts:
+#
+#   - egress CAKE on the WAN interface          (ul_if)
+#   - ingress CAKE on an IFB device             (dl_if)
+#     fed by a tc ingress redirect from the WAN
+#
+# Interfaces and the initial (base) shaper rates are read from the SAME instance
+# config that cake-autorate.sh uses, so there is a single source of truth. After
+# this runs, start cake-autorate normally and it takes over the bandwidth.
+#
+# Usage:
+#   sqm-setup.sh start [CONFIG]   set up the qdiscs   (CONFIG default: ./config.primary.sh)
+#   sqm-setup.sh stop  [CONFIG]   tear the qdiscs down
+#
+# Extra CAKE options (diffserv mode, overhead, rtt, …) may be supplied per
+# direction via the optional config variables sqm_dl_cake_opts / sqm_ul_cake_opts.
+
+set -euo pipefail
+
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+
+action=start
+case "${1:-}" in
+	start | stop)
+		action=$1
+		shift
+		;;
+	*) ;; # leave action=start; treat $1 as the config path
+esac
+config=${1:-${script_dir}/config.primary.sh}
+
+if [[ ! -f ${config} ]]; then
+	printf >&2 'sqm-setup.sh: config not found: %s\n' "${config}"
+	exit 1
+fi
+
+# Pull dl_if / ul_if and the base rates from defaults + instance config.
+# shellcheck source=/dev/null
+. "${script_dir}/defaults.sh"
+# shellcheck source=/dev/null
+. "${config}"
+
+: "${dl_if:?sqm-setup.sh: dl_if is not set in the config}"
+: "${ul_if:?sqm-setup.sh: ul_if is not set in the config}"
+: "${base_dl_shaper_rate_kbps:?sqm-setup.sh: base_dl_shaper_rate_kbps is not set}"
+: "${base_ul_shaper_rate_kbps:?sqm-setup.sh: base_ul_shaper_rate_kbps is not set}"
+
+# Optional per-direction extra CAKE keywords. The defaults give full per-host
+# fairness on a NAT router, like OpenWrt SQM: "nat" resolves the inside hosts,
+# and dual-srchost (egress) / dual-dsthost (ingress) share bandwidth per LAN
+# host, so no single host can starve the others. Override in the config if needed.
+sqm_dl_cake_opts=${sqm_dl_cake_opts:-nat dual-dsthost ingress}
+sqm_ul_cake_opts=${sqm_ul_cake_opts:-nat dual-srchost}
+
+teardown() {
+	tc qdisc del root dev "${ul_if}" 2>/dev/null || true
+	tc qdisc del dev "${ul_if}" ingress 2>/dev/null || true
+	ip link del "${dl_if}" 2>/dev/null || true
+}
+
+case ${action} in
+	stop)
+		teardown
+		;;
+	start)
+		if ! ip link show "${ul_if}" >/dev/null 2>&1; then
+			printf >&2 'sqm-setup.sh: WAN interface "%s" (ul_if) not found\n' "${ul_if}"
+			exit 1
+		fi
+		modprobe ifb 2>/dev/null || true
+		modprobe sch_cake 2>/dev/null || true
+		teardown
+		trap teardown ERR # roll back a partial setup if any command below fails
+
+		# Upload: shape egress on the WAN interface.
+		# shellcheck disable=SC2086
+		tc qdisc add root dev "${ul_if}" cake \
+			bandwidth "${base_ul_shaper_rate_kbps}kbit" ${sqm_ul_cake_opts}
+
+		# Download: redirect WAN ingress into an IFB and shape that.
+		ip link add "${dl_if}" type ifb
+		ip link set "${dl_if}" up
+		tc qdisc add dev "${ul_if}" handle ffff: ingress
+		tc filter add dev "${ul_if}" parent ffff: protocol all \
+			u32 match u32 0 0 action mirred egress redirect dev "${dl_if}"
+		# shellcheck disable=SC2086
+		tc qdisc add root dev "${dl_if}" cake \
+			bandwidth "${base_dl_shaper_rate_kbps}kbit" ${sqm_dl_cake_opts}
+		trap - ERR
+		;;
+	*)
+		printf >&2 'sqm-setup.sh: unknown action: %s\n' "${action}"
+		exit 1
+		;;
+esac

--- a/sqm-setup.sh
+++ b/sqm-setup.sh
@@ -73,7 +73,10 @@ case ${action} in
 			printf >&2 'sqm-setup.sh: WAN interface "%s" (ul_if) not found\n' "${ul_if}"
 			exit 1
 		fi
-		modprobe ifb 2>/dev/null || true
+		# numifbs=0 so the module doesn't auto-create stray ifb0/ifb1 (which would
+		# otherwise pick up IPv4LL 169.254 addresses); we add a named IFB below.
+		# (Only takes effect on the module's first load, i.e. a clean boot.)
+		modprobe ifb numifbs=0 2>/dev/null || true
 		modprobe sch_cake 2>/dev/null || true
 		teardown
 		trap teardown ERR # roll back a partial setup if any command below fails

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -44,10 +44,18 @@ main() {
 		[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/jffs/configs/cake-autorate
 	fi
 
-	# If we are not running on OpenWRT or ASUSWRT-Merlin, exit
+	# Check for a generic Linux host with OpenRC (matches setup.sh).
+	if [ "${MY_OS}" = "unknown" ] && command -v rc-update >/dev/null 2>&1 && command -v rc-service >/dev/null 2>&1
+	then
+		MY_OS=linux-openrc
+		[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/root/cake-autorate
+		[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/root/cake-autorate
+	fi
+
+	# If we are not running on a supported OS, exit
 	if [ "${MY_OS}" = "unknown" ]
 	then
-		printf "This script requires OpenWrt or ASUSWRT-Merlin\n" >&2
+		printf "This script requires OpenWrt, ASUSWRT-Merlin, or a Linux host with OpenRC\n" >&2
 		return 1
 	fi
 
@@ -59,6 +67,11 @@ main() {
 	if [ -x /etc/init.d/mqtt-publisher ]
 	then
 		/etc/init.d/mqtt-publisher stop || :
+	fi
+	# On OpenRC, also remove the service from its runlevel.
+	if [ "${MY_OS}" = "linux-openrc" ]
+	then
+		rc-update del cake-autorate 2>/dev/null || :
 	fi
 	rm -f /etc/init.d/cake-autorate /etc/rc.d/*cake-autorate
 	rm -f /etc/init.d/mqtt-publisher /etc/rc.d/*mqtt-publisher
@@ -100,7 +113,7 @@ main() {
 
 	# remove current program files from the cake-autorate directory
 	cd "${SCRIPT_PREFIX}"
-	files="cake-autorate.sh defaults.sh launcher.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh"
+	files="cake-autorate.sh defaults.sh launcher.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh sqm-setup.sh version.txt"
 	for file in ${files}
 	do
 		rm -f "${file}"


### PR DESCRIPTION
## What

Adds first-class support for running cake-autorate on a **generic Linux router
with OpenRC** (Alpine, Gentoo, Artix, …), alongside the existing OpenWrt and
ASUSWRT-Merlin targets. Purely additive — the existing paths are untouched.

On OpenWrt the SQM package creates the CAKE qdiscs and cake-autorate only
*adjusts* their bandwidth. A bare Linux router has no SQM, so this adds a small
helper that brings the qdiscs up the way cake-autorate then expects.

## Changes

- **`setup.sh` / `uninstall.sh`**: detect a generic-Linux-with-OpenRC host
  (`rc-update` + `rc-service` present) → installs `/etc/init.d/cake-autorate`
  from a new OpenRC template. The GitHub-API "latest commit" lookup is made
  portable (no `jsonfilter`, which is OpenWrt-only) via `grep`/`sed`.
- **`cake-autorate.openrc.template`** (new): an `openrc-run` service — `start_pre`
  brings the qdiscs up, the launcher runs the instance(s), `stop_post` tears them
  down. It **appends** to PATH (`/usr/sbin:/sbin`) rather than overwriting, so
  OpenRC's own helpers stay reachable while `tc`/`ip`/`modprobe` resolve.
- **`sqm-setup.sh`** (new): minimal CAKE bring-up — egress CAKE on the WAN iface
  + an IFB fed by a `tc` ingress redirect, with per-host fairness
  (`nat dual-srchost` egress / `nat dual-dsthost ingress`). Interfaces + base
  rates are read from the SAME instance config (single source of truth).
- **`launcher.sh.template`**: `shopt -s nullglob` + empty-array guard, so a
  missing config set fails cleanly instead of expanding to a literal-glob path.
- **Tree is now shellcheck-clean** (`.shellcheckrc` + targeted directives); also
  fixed a `proc_pids` pinger-PID indexing bug found while linting.
- **`INSTALLATION-linux-openrc.md`** (new): install/config/run docs.

## Testing

Validated end-to-end on a real **Alpine 3.23 / OpenRC** router (Protectli N150,
Starlink WAN): the service starts at boot, the qdiscs come up, cake-autorate
adjusts the shaper under load, and `stop` tears everything down cleanly.

## Notes

`sqm-setup.sh` is only used on the generic-Linux path (OpenWrt still relies on its
SQM package). Extra CAKE keywords can be overridden per-direction via
`sqm_dl_cake_opts` / `sqm_ul_cake_opts` in the config.
