### PR TITLE
Fix multi-pinger PID + launcher empty-config guard + shellcheck cleanup

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -21,3 +21,14 @@ enable=all
 
 # Allow shellcheck to access arbitrary files
 external-sources=true
+
+# Prefer ${var} braces (opt-in style; the codebase mixes both intentionally).
+disable=SC2250
+
+# $ / ${ } around arithmetic operands is unnecessary (cosmetic).
+disable=SC2004
+
+# Intentional array->string joins (the CPU-stat lines reuse the array name as
+# a scalar via ${arr[*]} then ${scalar// /...}); not bugs.
+disable=SC2178
+disable=SC2128

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -497,6 +497,7 @@ start_pinger()
 		irtt)
 			sleep_until_next_pinger_time_slot "${pinger}"
 
+			# shellcheck disable=SC2155  # the subshell status (echo $!) is intentionally unused
 			local pinger_pid=$( (
 				set -m
 				${ping_prefix_string} gawk -v extra_args="${ping_extra_args}" -v interval_s="${reflector_ping_interval_s}" -v duration_m="${irtt_session_duration_m}" -v reflector="${reflectors[$pinger]}" -f <(cat <<-'EOT'
@@ -693,15 +694,16 @@ replace_pinger_reflector()
 		# shellcheck disable=SC2206
 		reflectors+=(${bad_reflector})
 		# reset array indices
+		# shellcheck disable=SC2206
 		reflectors=(${reflectors[@]})
 		if ((retain_reflector_stats==0))
 		then
 			log_msg "DEBUG" "Discarding reflector stats associated with ${bad_reflector}"
-			unset dl_owd_baselines_us[${bad_reflector}]
-			unset ul_owd_baselines_us[${bad_reflector}]
-			unset dl_owd_delta_ewmas_us[${bad_reflector}]
-			unset ul_owd_delta_ewmas_us[${bad_reflector}]
-			unset last_timestamp_reflectors_us[${bad_reflector}]
+			unset "dl_owd_baselines_us[${bad_reflector}]"
+			unset "ul_owd_baselines_us[${bad_reflector}]"
+			unset "dl_owd_delta_ewmas_us[${bad_reflector}]"
+			unset "ul_owd_delta_ewmas_us[${bad_reflector}]"
+			unset "last_timestamp_reflectors_us[${bad_reflector}]"
 		else
 			log_msg "DEBUG" "Retaining reflector stats associated with: ${bad_reflector}"
 		fi
@@ -1036,7 +1038,7 @@ esac
 cpu_idx=0
 while :
 do
-	read -r cpu_id rem
+	read -r cpu_id _
 	case ${cpu_id} in
 		cpu*)
 			cpu_ids[cpu_idx]=${cpu_id^^}
@@ -1047,7 +1049,7 @@ do
 			;;
 	esac
 done</proc/stat
-cpu_ids="${cpu_ids[@]}"
+cpu_ids="${cpu_ids[*]}"
 ((cpu_cores=cpu_idx-1))
 log_msg "DEBUG" "Detected ${cpu_cores} CPU cores."
 mapfile -t cpu_usage < <(for ((i=0; i <= cpu_cores; i++)); do echo 0; done)
@@ -1716,7 +1718,7 @@ do
 						read -r -a cpu_stats
 						if (( output_cpu_stats ))
 						then
-							cpu_stats_vals=${cpu_stats[@]:1}
+							cpu_stats_vals=${cpu_stats[*]:1}
 							((
 								cpu_sum=${cpu_stats_vals// /+},
 								cpu_delta=cpu_sum-last_cpu_sum[cpu_idx],
@@ -1728,13 +1730,13 @@ do
 						fi
 						if (( output_cpu_raw_stats ))
 						then
-							cpu_raw_stats="${cpu_stats[@]}"	cpu_raw_stats="${stats_read_time_us}; ${cpu_raw_stats// /; }"
+							cpu_raw_stats="${cpu_stats[*]}"	cpu_raw_stats="${stats_read_time_us}; ${cpu_raw_stats// /; }"
 							log_msg "CPU_RAW" "${cpu_raw_stats}"
 						fi
 					done</proc/stat
 					if (( output_cpu_stats ))
 					then
-						cpu_stats="${cpu_usage[@]}" cpu_stats="${stats_read_time_us}; ${cpu_stats// /; }"
+						cpu_stats="${cpu_usage[*]}" cpu_stats="${stats_read_time_us}; ${cpu_stats// /; }"
 						log_msg "CPU" "${cpu_stats}"
 					fi
 					t_last_cpu_usage_check_us=${t_start_us}

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -574,7 +574,7 @@ start_pinger()
 			sleep_until_next_pinger_time_slot "${pinger}"
 			${ping_prefix_string} ping ${ping_extra_args} -D -i "${reflector_ping_interval_s}" "${reflectors[pinger]}" 2> /dev/null >&"${main_fd}" &
 			pinger_pids[pinger]=${!}
-			proc_pids["ping_${pinger}_pinger"]=${pinger_pids[0]}
+			proc_pids["ping_${pinger}_pinger"]=${pinger_pids[pinger]}
 			;;
 		*)
 			log_msg "ERROR" "Unknown pinger method: ${pinger_method}"

--- a/cake-autorate.template
+++ b/cake-autorate.template
@@ -1,4 +1,5 @@
 #!/bin/sh /etc/rc.common
+# shellcheck disable=SC2034
 
 START=97
 STOP=4

--- a/config.primary.sh
+++ b/config.primary.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 # *** INSTANCE-SPECIFIC CONFIGURATION OPTIONS ***
 # 

--- a/defaults.sh
+++ b/defaults.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 
 # defaults.sh -- default configuration values for cake-autorate.sh
 #

--- a/launcher.sh.template
+++ b/launcher.sh.template
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# shellcheck shell=bash
+
+# An unmatched glob must expand to nothing (not the literal pattern), so a
+# missing config set yields an empty array instead of a bogus instance path.
+shopt -s nullglob
 
 cake_instances=()
 if command -v uci >/dev/null 2>&1 && uci show cake-autorate >/dev/null 2>&1
@@ -20,6 +25,13 @@ then
 else
 	cake_instances=(%%CONFIG_PREFIX%%/config.*.sh)
 fi
+
+if [[ ${#cake_instances[@]} -eq 0 ]]
+then
+	printf '%s\n' "cake-autorate: no config files found in %%CONFIG_PREFIX%%" >&2
+	exit 1
+fi
+
 cake_instance_pids=()
 
 trap kill_cake_instances INT TERM EXIT

--- a/mqtt-publisher.sh
+++ b/mqtt-publisher.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155
 
 CPU_CORES=$(grep -c '^processor' /proc/cpuinfo) || { echo "ERROR: failed to detect CPU core count from /proc/cpuinfo" >&2; exit 1; }
 

--- a/mqtt-publisher.template
+++ b/mqtt-publisher.template
@@ -1,4 +1,5 @@
 #!/bin/sh /etc/rc.common
+# shellcheck disable=SC2034
 
 START=98
 STOP=10


### PR DESCRIPTION
## What

Two small, self-contained improvements, split out of #362 as you asked (the
parts that were unrelated to the OpenRC work).

## Changes

- **`fix`: correct pinger PID tracking in multi-pinger `ping` mode** — in the
  round-robin `ping)` method each reflector gets its own pinger indexed by
  `${pinger}`, but `proc_pids` recorded `pinger_pids[0]` for every reflector
  instead of `pinger_pids[pinger]`, so all but the first pinger were tracked
  under the wrong PID.
- **`fix`: launcher exits cleanly when no instance config is found** —
  `shopt -s nullglob` so an unmatched `config.*.sh` glob expands to nothing
  instead of a literal pattern, plus a guard that reports the missing config and
  exits non-zero rather than launching an instance with a bogus path.
- **`chore`: shellcheck-clean the tree** — quote `SC2184` unset targets, `_` for
  a throwaway `read` var, `[*]` for the intentional array→string joins on the
  CPU-stat lines, targeted `SC2155`/`SC2206` directives, and a few file-level
  disables in `.shellcheckrc`. No behaviour change.

Three atomic commits; the core loop is untouched.
