### PR TITLE
lib.sh: fix terminate() negative-pgid handling + Fisher-Yates bias

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -114,7 +114,11 @@ randomize_array()
 
 	for ((set=${#array[@]}-1; set>0; set--))
 	do
-		idx=$((RANDOM%set))
+		# j must be uniform in [0, set] INCLUSIVE for an unbiased Fisher-Yates.
+		# RANDOM%set gives [0, set-1], excluding the current index -> that is
+		# Sattolo's algorithm (only cyclic permutations; an element can never
+		# stay put), which biases the startup reflector shuffle.
+		idx=$((RANDOM%(set+1)))
 		temp=${array[set]}
 		array[set]=${array[idx]}
 		array[idx]=${temp}

--- a/lib.sh
+++ b/lib.sh
@@ -133,7 +133,11 @@ terminate()
 
 	read -r -a pids <<< "${pids}"
 
-	kill "${pids[@]}" 2> /dev/null
+	# `--` is required: for the irtt pinger method pids are negated pgids (set -m),
+	# and `kill -123` parses the leading dash as a signal spec ("invalid signal
+	# specification") and delivers nothing -- so the graceful TERM (and, with >1
+	# pinger, the -9 fallback too) silently no-op and irtt children leak.
+	kill -TERM -- "${pids[@]}" 2> /dev/null
 
 	for ((i=0; i<timeout_ms; i+=100))
 	do
@@ -145,7 +149,7 @@ terminate()
 		sleep_s 0.1
 	done
 
-	kill -9 "${pids[@]}" 2> /dev/null
+	kill -KILL -- "${pids[@]}" 2> /dev/null
 }
 
 if (( __set_e == 1 ))


### PR DESCRIPTION
Two small, independent correctness fixes in `lib.sh` (kept as two commits).

### `terminate()`: pass `--` before (negative) pids
For `pinger_method=irtt` the pinger pids are negated pgids (`set -m`), so
`kill "${pids[@]}"` sees a leading `-<pgid>` and parses it as a **signal spec**
(`invalid signal specification`), aborting the call and delivering nothing. The
graceful `TERM` on every reflector stop/replace and on cleanup therefore no-ops,
and with more than one irtt pinger the `-9` fallback aborts the same way, leaking
the `gawk`/`irtt` children across restarts. Fixed with `kill -TERM -- …` /
`kill -KILL -- …` so the negative pgids are treated as targets.

### `randomize_array()`: Sattolo's → Fisher-Yates
The function is documented as Fisher-Yates but uses `RANDOM%set` (j in
`[0, set-1]`, excluding the current index) — that is Sattolo's algorithm: only
cyclic permutations, non-uniform (an element can never stay put). `RANDOM%(set+1)`
gives the inclusive `[0, set]` an unbiased shuffle needs. Low impact (reflectors
are interchangeable and runtime swapping dilutes the startup bias), but it
contradicts the stated intent.

`shellcheck -x` and `bash -n` clean.
