### PR TITLE
Installer robustness: setup.sh exec-after-rm + uninstall.sh CONFIG_PREFIX guard

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -174,7 +174,9 @@ main() {
 				exec "${tmp}/setup.sh" "${REPOSITORY}" "${BRANCH}"
 		else
 			printf "Self-replacing not fully supported. Restarting with the new setup.sh...\n"
-			rm -rf "${tmp}"
+			# Do NOT rm -rf "${tmp}" here: exec immediately runs ${tmp}/setup.sh,
+			# so deleting it first makes the exec fail with ENOENT and aborts the
+			# restart. The EXIT/INT/TERM trap removes ${tmp} if the exec fails.
 			exec "${tmp}/setup.sh" "${REPOSITORY}" "${BRANCH}"
 		fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -172,15 +172,14 @@ main() {
 			__CAKE_AUTORATE_SETUP_SH_EXEC_TMP="${tmp}" \
 			__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT="${commit}" \
 				exec "${tmp}/setup.sh" "${REPOSITORY}" "${BRANCH}"
-		else
-			printf "Self-replacing not fully supported. Restarting with the new setup.sh...\n"
-			# Do NOT rm -rf "${tmp}" here: exec immediately runs ${tmp}/setup.sh,
-			# so deleting it first makes the exec fail with ENOENT and aborts the
-			# restart. The EXIT/INT/TERM trap removes ${tmp} if the exec fails.
-			exec "${tmp}/setup.sh" "${REPOSITORY}" "${BRANCH}"
 		fi
 
-		exit "${?}"  # should not reach this point
+		# The downloaded setup.sh lacks the self-replacing marker. That only
+		# happens when installing a pre-self-replacing (pre-2024) version, which
+		# cannot perform the preserved-tmp handoff. Rather than exec the old
+		# script, fall through and install the downloaded files with the current
+		# setup.sh. (The previous code rm-ed "${tmp}" then exec'd it -> ENOENT.)
+		printf "Downloaded setup.sh predates self-replacing; continuing with the current installer.\n"
 	fi
 
 	# Migrate old configuration (and new file) files if present

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -75,40 +75,45 @@ main() {
 	# remove configuration files if user does not want to keep them.
 	# Guard the cd: a missing CONFIG_PREFIX (configs already removed, or a custom
 	# prefix never created -- e.g. Merlin's separate /jffs/configs) would abort the
-	# whole uninstall under set -eu BEFORE the program files below are removed,
-	# leaving them on disk. If it is absent there are no configs to remove anyway.
-	if [ -d "${CONFIG_PREFIX}" ]; then cd "${CONFIG_PREFIX}"; else cd "${SCRIPT_PREFIX}"; fi
-	keepIt=''
-	for file in *config.*.sh*
-	do
-		[ -e "${file}" ] || continue   # handle case where there are no old config files
-		if [ -z "${keepIt:-}" ]
-	        then
-	                printf "Would you like to keep your configs? [Y/n]"
-	                read -r keepIt
-	                [ -z "${keepIt:-}" ] && keepIt=Y
-	        fi
+	# whole uninstall under set -eu before the program files below are removed.
+	# If it is absent there are no configs to remove anyway.
+	if [ -d "${CONFIG_PREFIX}" ]
+	then
+		cd "${CONFIG_PREFIX}"
+		keepIt=''
+		for file in *config.*.sh*
+		do
+			[ -e "${file}" ] || continue   # handle case where there are no old config files
+			if [ -z "${keepIt:-}" ]
+			then
+				printf "Would you like to keep your configs? [Y/n]"
+				read -r keepIt
+				[ -z "${keepIt:-}" ] && keepIt=Y
+			fi
 
-		if [ "${keepIt}" = "N" ] || [ "${keepIt}" = "n" ]; then
+			if [ "${keepIt}" = "N" ] || [ "${keepIt}" = "n" ]; then
+				rm -f "${file}"
+			fi
+		done
+	fi
+
+	# remove program files (old and current names) from the script directory.
+	# Same guard rationale: skip cleanly if SCRIPT_PREFIX is absent.
+	if [ -d "${SCRIPT_PREFIX}" ]
+	then
+		cd "${SCRIPT_PREFIX}"
+		old_fnames="cake-autorate.sh cake-autorate_defaults.sh cake-autorate_launcher.sh cake-autorate_lib.sh cake-autorate_setup.sh"
+		for file in ${old_fnames}
+		do
 			rm -f "${file}"
-	        fi
-	done
+		done
 
-	# remove old program files from cake-autorate directory
-	cd "${SCRIPT_PREFIX}"
-	old_fnames="cake-autorate.sh cake-autorate_defaults.sh cake-autorate_launcher.sh cake-autorate_lib.sh cake-autorate_setup.sh"
-	for file in ${old_fnames}
-	do
-		rm -f "${file}"
-	done
-
-	# remove current program files from the cake-autorate directory
-	cd "${SCRIPT_PREFIX}"
-	files="cake-autorate.sh defaults.sh launcher.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh"
-	for file in ${files}
-	do
-		rm -f "${file}"
-	done
+		files="cake-autorate.sh defaults.sh launcher.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh"
+		for file in ${files}
+		do
+			rm -f "${file}"
+		done
+	fi
 
 	# remove ${SCRIPT_PREFIX} and ${CONFIG_PREFIX} directories if empty
 	rmdir "${SCRIPT_PREFIX}" "${CONFIG_PREFIX}" 2>/dev/null || :

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -72,8 +72,12 @@ main() {
 		exit 1
 	fi
 
-	# remove configuration files if user does not want to keep them
-	cd "${CONFIG_PREFIX}"
+	# remove configuration files if user does not want to keep them.
+	# Guard the cd: a missing CONFIG_PREFIX (configs already removed, or a custom
+	# prefix never created -- e.g. Merlin's separate /jffs/configs) would abort the
+	# whole uninstall under set -eu BEFORE the program files below are removed,
+	# leaving them on disk. If it is absent there are no configs to remove anyway.
+	if [ -d "${CONFIG_PREFIX}" ]; then cd "${CONFIG_PREFIX}"; else cd "${SCRIPT_PREFIX}"; fi
 	keepIt=''
 	for file in *config.*.sh*
 	do


### PR DESCRIPTION
Two small installer hygiene fixes (one per file, one commit each).

### `setup.sh`: don't `rm -rf "${tmp}"` right before `exec`'ing it
The non-self-replacing restart branch removed `${tmp}` and then
`exec "${tmp}/setup.sh"`, so the `exec` always failed with ENOENT and aborted the
restart, leaving a half-finished install. Dropped the premature `rm`; the
`EXIT/INT/TERM` trap still removes `${tmp}` if the `exec` fails. (Narrow reach:
only downloads predating the `SELF_REPLACING` marker take this branch.)

### `uninstall.sh`: guard `cd "${CONFIG_PREFIX}"`
Under `set -eu`, `cd "${CONFIG_PREFIX}"` aborted the whole uninstall when the
config dir didn't exist (configs already removed, a re-run after a partial
uninstall, or a Merlin/custom prefix that diverges from `SCRIPT_PREFIX`), leaving
`cake-autorate.sh`/`lib.sh`/etc. on disk. Guarded so program-file removal still
runs.

`sh -n` / `shellcheck -x` clean (the pre-existing SC2310 infos in `setup.sh` are
unrelated and untouched).
