### PR TITLE
fix: generate_run_token uses od, not hexdump (avoid non-Essential bsdextrautils)

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -129,7 +129,7 @@ generate_run_token()
 {
 	local run_token
 
-	run_token=$(head -c 32 /dev/urandom 2>/dev/null | hexdump -v -e '/1 "%02x"') || return 1
+	run_token=$(head -c 32 /dev/urandom 2>/dev/null | od -An -v -tx1 | tr -d ' \n') || return 1
 	[[ ${#run_token} -eq 64 ]] || return 1
 
 	printf '%s\n' "${run_token}"


### PR DESCRIPTION
Follow-up to #369, which added `generate_run_token()`.

`generate_run_token()` (lib.sh) pipes `/dev/urandom` through **`hexdump`**:

```sh
run_token=$(head -c 32 /dev/urandom 2>/dev/null | hexdump -v -e '/1 "%02x"') || return 1
```

`hexdump` is **not** part of coreutils. On Debian it ships in the *non-Essential* `bsdextrautils` package, so on a minimal Debian box it can be absent. With `set -o pipefail` the missing binary makes the pipeline return non-zero *and* fails the `[[ ${#run_token} -eq 64 ]]` check, so `generate_run_token` returns 1. The call site is **unconditional** (every startup, any `pinger_method`) and treats that as fatal:

```
Failed to generate CAKE_AUTORATE_RUN_TOKEN. Exiting now.
```

→ the daemon never starts on a minimal Debian install.

**Fix:** use `od` (coreutils — present on Debian *and* busybox/OpenWrt):

```sh
run_token=$(head -c 32 /dev/urandom 2>/dev/null | od -An -v -tx1 | tr -d ' \\n') || return 1
```

Byte-identical output (64 lowercase hex chars) verified. Strict portability improvement, no behaviour change. `shellcheck`/`bash -n` clean.