### PR TITLE
fix: per-reflector key handling (ping IPv6 colon strip + comparison guard)

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1571,7 +1571,11 @@ do
 
 						;;
 					ping)
-						reflector=${reflector//:/} seq=${seq//icmp_seq=} rtt_ms=${rtt_ms//time=}
+						# iputils ping -D prints "from <addr>:" -- strip only the trailing
+						# colon. ${reflector//:/} stripped EVERY colon, mangling IPv6 keys
+						# (2606:4700:4700::1111 -> 2606470047001111) so per-reflector tracking
+						# split across two keys; the irtt/tsping/fping paths key verbatim.
+						reflector=${reflector%:} seq=${seq//icmp_seq=} rtt_ms=${rtt_ms//time=}
 
 						printf -v rtt_us %.3f "${rtt_ms}"
 
@@ -1861,7 +1865,7 @@ do
 
 					t_last_reflector_comparison_us=${t_start_us}
 
-					[[ "${dl_owd_baselines_us[${reflectors[0]}]:-}" && "${dl_owd_baselines_us[${reflectors[0]}]:-}" && "${ul_owd_baselines_us[${reflectors[0]}]:-}" && "${ul_owd_baselines_us[${reflectors[0]}]:-}" ]] || continue
+					[[ "${dl_owd_baselines_us[${reflectors[0]}]:-}" && "${dl_owd_delta_ewmas_us[${reflectors[0]}]:-}" && "${ul_owd_baselines_us[${reflectors[0]}]:-}" && "${ul_owd_delta_ewmas_us[${reflectors[0]}]:-}" ]] || continue
 
 					((
 						min_sum_owd_baselines_us = dl_owd_baselines_us[${reflectors[0]}] + ul_owd_baselines_us[${reflectors[0]}],


### PR DESCRIPTION
Two associative-array key defects in the reflector parse/comparison logic.

### 1. `pinger_method=ping` mangles IPv6 reflector keys (`cake-autorate.sh:1574`)
iputils `ping -D` prints the address with a trailing colon (`from <addr>:`). The parse line strips **every** colon:
```sh
reflector=${reflector//:/} …
```
so `2606:4700:4700::1111:` → key `2606470047001111`. Init (`:1267`) and the comparison loop (`:1872-1874`) key on the verbatim colon form, so per-reflector OWD/baseline/EWMA/health tracking is silently split across two keys (reads 0 under `set -u`, no crash) for **every IPv6 reflector** under `pinger_method=ping`. The irtt/tsping/fping paths already key verbatim.

**Fix:** `reflector=${reflector%:}` — strip only the trailing colon (IPv4 and IPv6 both preserved).

### 2. Reflector-comparison guard tests the wrong keys (`cake-autorate.sh:1864`)
```sh
[[ "${dl_owd_baselines_us[r0]:-}" && "${dl_owd_baselines_us[r0]:-}" && "${ul_owd_baselines_us[r0]:-}" && "${ul_owd_baselines_us[r0]:-}" ]] || continue
```
tests `dl_owd_baselines_us[r0]` **twice** and `ul_owd_baselines_us[r0]` **twice**, but the block then reads `dl_owd_delta_ewmas_us[r0]` / `ul_owd_delta_ewmas_us[r0]` (`:1868-1869`) which it never guards. Copy-paste defect — the very next loop (`:1874`) guards the four **distinct** arrays correctly. Latent today (baselines+EWMAs created/destroyed in lockstep), but the guard protects nothing it was written to protect. Fixed to mirror `:1874`.

`bash -n` / `shellcheck` clean.