### PR TITLE
harden: reflectors_url fetch — quote URL, curl/wget probe, TLS warning

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1026,7 +1026,22 @@ log_msg "DEBUG" "Local list of reflectors contains ${#reflectors[*]} entries."
 if [[ -n ${reflectors_url} ]]
 then
 	log_msg "DEBUG" "Appending local list of reflectors with remote list of reflectors at: ${reflectors_url}."
-	readarray -t -s ${reflectors_url_skip_lines} -O ${#reflectors[*]} reflectors < <( wget -O - ${reflectors_url} 2>/dev/null | awk -F "," '{ print $1 }' )
+	[[ ${reflectors_url} == https://* ]] || log_msg "WARNING" "reflectors_url is not https:// -- the remote reflector list is fetched without TLS and can be tampered with in transit."
+	# Quote the URL: the global IFS contains a comma, so an unquoted URL with a
+	# comma in its query string would be split into several fetch operands. Probe
+	# curl-then-wget so the fetch also works on hosts that ship only one of them
+	# (it previously hardcoded wget and silently appended nothing where only curl
+	# was installed).
+	if command -v curl &> /dev/null
+	then
+		readarray -t -s "${reflectors_url_skip_lines}" -O "${#reflectors[*]}" reflectors < <( curl -fsS "${reflectors_url}" 2>/dev/null | awk -F "," '{ print $1 }' )
+	elif command -v wget &> /dev/null
+	then
+		readarray -t -s "${reflectors_url_skip_lines}" -O "${#reflectors[*]}" reflectors < <( wget -O - "${reflectors_url}" 2>/dev/null | awk -F "," '{ print $1 }' )
+	else
+		log_msg "ERROR" "reflectors_url is set but neither curl nor wget is available. Exiting script."
+		exit 1
+	fi
 	log_msg "DEBUG" "Local list of reflectors now contains ${#reflectors[*]} entries."
 fi
 


### PR DESCRIPTION
Three issues in the single `reflectors_url` fetch statement (`cake-autorate.sh:1029`):

```sh
readarray -t -s ${reflectors_url_skip_lines} -O ${#reflectors[*]} reflectors \
    < <( wget -O - ${reflectors_url} 2>/dev/null | awk -F "," '{ print $1 }' )
```

1. **Unquoted URL + comma in `IFS`.** The global `IFS` contains a comma (set near line 28), so an unquoted `${reflectors_url}` with a comma in its query string is word-split into several `wget` operands (a split fragment starting with `-` would even be read as an option).
2. **`wget` hardcoded.** No presence check; on a host that ships only `curl` the fetch is command-not-found, stderr is `/dev/null`'d, and the remote list **silently appends nothing**. `setup.sh:download_url()` is already curl-first/wget-fallback and the irtt block already uses `command -v` probes — the daemon should match.
3. **No TLS notice.** The list is fetched over plain HTTP with no warning that it is unauthenticated/MITM-able.

**Fix:** quote the URL and the skip-lines/offset integers; probe curl-then-wget and error clearly if neither is present; `log_msg WARNING` when the URL is not `https://`. No behaviour change for an existing `https` + `wget` user.

`bash -n` / `shellcheck` clean.