### PR TITLE
fix: check for a conflicting instance before rotating the log; validate rate bounds

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -991,18 +991,14 @@ else
 	log_file_path="/var/log/cake-autorate${instance_id:+.${instance_id}}.log"
 fi
 
-rotate_log_file
-
-# save stderr fd, redirect stderr to intercept_stderr
-# intercept_stderr sends stderr to log_msg and exits cake-autorate
-exec {original_stderr_fd}>&2 2> >(intercept_stderr)
-
-proc_pids['intercept_stderr']=${!}
-
-log_msg "SYSLOG" "Starting cake-autorate with PID: ${BASHPID} and config: ${config_path}"
-
-# ${run_path}/ is used to store temporary files
-# it should not exist on startup so if it does exit, else create the directory
+# ${run_path}/ is used to store temporary files; it should not exist on startup.
+# Check for a conflicting running instance, and (re)create the dir, BEFORE
+# rotate_log_file: a redundant same-instance start (operator double-start,
+# overlapping restart, watchdog/cron re-exec) otherwise runs rotate_log_file --
+# which does `cat log > log.old; : > log` -- and truncates the live log of the
+# already-running instance (held open by its maintain_log_file) before this check
+# gets to exit. The check reads only the OTHER instance's on-disk run_token, and
+# this process writes its own only later, so it cannot false-positive on itself.
 if [[ -d ${run_path} ]]
 then
 	if running_main_pid=$(get_running_main_pid_for_run_path "${run_path}")
@@ -1018,6 +1014,16 @@ then
 else
 	mkdir -p "${run_path}"
 fi
+
+rotate_log_file
+
+# save stderr fd, redirect stderr to intercept_stderr
+# intercept_stderr sends stderr to log_msg and exits cake-autorate
+exec {original_stderr_fd}>&2 2> >(intercept_stderr)
+
+proc_pids['intercept_stderr']=${!}
+
+log_msg "SYSLOG" "Starting cake-autorate with PID: ${BASHPID} and config: ${config_path}"
 
 proc_pids['main']=${BASHPID}
 
@@ -1054,7 +1060,8 @@ case ${pinger_method} in
 		;;
 esac
 
-# Check no_pingers <= no_reflectors
+# Check 1 <= no_pingers <= no_reflectors
+(( no_pingers < 1 )) && { log_msg "ERROR" "no_pingers must be at least 1. Exiting script."; exit 1; }
 (( no_pingers > no_reflectors )) && { log_msg "ERROR" "number of pingers cannot be greater than number of reflectors. Exiting script."; exit 1; }
 
 # Check dl/if interface not the same
@@ -1066,6 +1073,16 @@ esac
 # Check if connection_active_thr_kbps is greater than min dl/ul shaper rate
 (( connection_active_thr_kbps > min_dl_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_dl_shaper_rate_kbps. Exiting script."; exit 1; }
 (( connection_active_thr_kbps > min_ul_shaper_rate_kbps )) && { log_msg "ERROR" "connection_active_thr_kbps cannot be greater than min_ul_shaper_rate_kbps. Exiting script."; exit 1; }
+
+# Check shaper rate bounds: 1 <= min <= base <= max for each direction. Without
+# this, base>max silently pins the link at max (the steady-state-is-base contract
+# is void), base<min pins at min, and min=0 reaches the load_percent /
+# compensation divides -> division by zero -> the daemon is killed via
+# intercept_stderr instead of exiting cleanly with a clear message.
+(( min_dl_shaper_rate_kbps < 1 )) && { log_msg "ERROR" "min_dl_shaper_rate_kbps must be at least 1. Exiting script."; exit 1; }
+(( min_ul_shaper_rate_kbps < 1 )) && { log_msg "ERROR" "min_ul_shaper_rate_kbps must be at least 1. Exiting script."; exit 1; }
+(( min_dl_shaper_rate_kbps > base_dl_shaper_rate_kbps || base_dl_shaper_rate_kbps > max_dl_shaper_rate_kbps )) && { log_msg "ERROR" "dl shaper rates must satisfy min <= base <= max. Exiting script."; exit 1; }
+(( min_ul_shaper_rate_kbps > base_ul_shaper_rate_kbps || base_ul_shaper_rate_kbps > max_ul_shaper_rate_kbps )) && { log_msg "ERROR" "ul shaper rates must satisfy min <= base <= max. Exiting script."; exit 1; }
 
 # Passed error checks
 


### PR DESCRIPTION
Three startup-time robustness fixes. The headline one completes the intent of #369.

### 1. Conflicting-instance check must run **before** `rotate_log_file` (data loss)
`rotate_log_file` runs unconditionally, and only *after* it does the #369 run-token conflict check `exit 1` a redundant start. But `rotate_log_file` does:
```sh
cat "${log_file_path}" > "${log_file_path}.old"
: > "${log_file_path}"
```
so a second **same-instance** start (operator double-start, an overlapping systemd restart, a watchdog/cron/hotplug re-exec) truncates the live log of the already-running instance — which `maintain_log_file` holds open via `exec {fd}>` — yielding a NUL-padded sparse hole then new data, and clobbers its `.old`. The #369 guard is meant to make double-starts safe, but the log-protecting half is defeated by statement order.

**Fix:** move the `if [[ -d ${run_path} ]] … fi` block to immediately before `rotate_log_file`. The detection reads only the *other* instance's on-disk `run_token`/`proc_pids` (this process writes its own later), so a moved-up check cannot false-positive on itself; a sole legitimate start (no/stale dir) proceeds to rotate exactly as today.

### 2. Guard `no_pingers >= 1` (CORRECTNESS-3)
`no_pingers` is validated only at the top (`> no_reflectors`). `no_pingers=0` reaches `reflector_ping_interval_us/no_pingers` → division by zero; since stderr is already wired to `intercept_stderr`, the daemon dies via the opaque kill path instead of a clean validation exit.

### 3. Validate `1 <= min <= base <= max` shaper rates (SHAPER-LOGIC-2)
Startup never checks the rate ordering. `base>max` silently pins the link at `max` (the steady-state-is-`base` contract is void), `base<min` pins at `min`, and `min=0` reaches the `load_percent`/compensation divides → division by zero → `intercept_stderr` kill. Additive guards mirroring the existing validation block.

`bash -n` / `shellcheck` clean.