### PR TITLE
harden: restrict the runtime dir to mode 0700

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1013,12 +1013,10 @@ then
 	else
 		log_msg "DEBUG" "${run_path} already exists but no conflicting instance is running. Removing and recreating."
 		rm -r "${run_path}"
-		mkdir -p "${run_path}"
-		chmod 0700 "${run_path}"
+		( umask 077 && mkdir -p "${run_path}" )
 	fi
 else
-	mkdir -p "${run_path}"
-	chmod 0700 "${run_path}"
+	( umask 077 && mkdir -p "${run_path}" )
 fi
 
 proc_pids['main']=${BASHPID}

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1014,9 +1014,11 @@ then
 		log_msg "DEBUG" "${run_path} already exists but no conflicting instance is running. Removing and recreating."
 		rm -r "${run_path}"
 		mkdir -p "${run_path}"
+		chmod 0700 "${run_path}"
 	fi
 else
 	mkdir -p "${run_path}"
+	chmod 0700 "${run_path}"
 fi
 
 proc_pids['main']=${BASHPID}


### PR DESCRIPTION
`mkdir -p "${run_path}"` creates the root-owned runtime directory with the process umask (typically `022` → world-readable). `${run_path}` holds `proc_pids`/`run_token` and the generated `log_file_export`/`log_file_reset` helper scripts, and the code already flags the directory as sensitive (the `mkdir -p ${run_path}`/`rm -r ${run_path}` warning banner). Least-privilege for a root-owned runtime dir: create it, then `chmod 0700`.

`chmod` after `mkdir` rather than `mkdir -m 0700` to avoid `shellcheck` SC2174 (`-m` with `-p` only applies to the deepest dir) and to guarantee the mode on the final directory.

No behaviour change for the daemon (runs as root). `bash -n` / `shellcheck` clean.