### PR TITLE
fix: clear the log-export result marker before signalling (race)

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -260,6 +260,12 @@ generate_log_file_scripts()
 
 	timeout_s=\${1:-20}
 
+	# Clear the previous result marker BEFORE signalling. The daemon's
+	# export_log_file writes this marker; removing it *after* the signal can
+	# delete a freshly-written one, so the wait below would time out even though
+	# the export succeeded.
+	rm -f "${run_path}/last_log_file_export"
+
 	if kill -USR1 "${proc_pids['maintain_log_file']}"
 	then
 		printf "Successfully signalled maintain_log_file process to request log file export.\n"
@@ -267,7 +273,6 @@ generate_log_file_scripts()
 		printf "ERROR: Failed to signal maintain_log_file process.\n" >&2
 		exit 1
 	fi
-	rm -f "${run_path}/last_log_file_export"
 
 	read_try=0
 


### PR DESCRIPTION
The generated `log_file_export` helper (`generate_log_file_scripts`) does:

```sh
if kill -USR1 "${maintain_log_file_pid}"   # signal first
then …
fi
rm -f "${run_path}/last_log_file_export"   # then remove the previous marker
while [[ ! -f "${run_path}/last_log_file_export" ]]   # then wait for a fresh one
do sleep 1; … timeout … done
```

The daemon's `export_log_file` writes `last_log_file_export` on USR1. If it runs **between** the `kill` and the `rm`, the helper deletes the just-written marker, never sees a fresh one, and exits 1 with a spurious "Timeout reached" even though the export completed on disk.

**Fix:** clear the marker *before* signalling. One-line reorder. (`log_file_reset` has no marker wait, so it is unaffected.)

`bash -n` / `shellcheck` clean.