### PR TITLE
harden: validate reflectors before use (irtt command injection)

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1050,6 +1050,19 @@ then
 	log_msg "DEBUG" "Local list of reflectors now contains ${#reflectors[*]} entries."
 fi
 
+# Validate every reflector before use. For pinger_method=irtt a reflector is
+# interpolated into a shell command (gawk builds "irtt client ... '<reflector>'"
+# and runs it via | getline), so a reflector containing shell metacharacters is
+# command injection -- and reflectors can come unvalidated from the remote
+# reflectors_url (fetched over the network above, possibly without TLS) or from
+# a hand-edited config. Allow only IP-/hostname-shaped strings (no quotes, ';',
+# spaces, '$', etc.); the first char excludes '-' (blocks option injection) but
+# admits ':' for compressed IPv6 (e.g. ::1, ::ffff:1.2.3.4).
+for reflector in "${reflectors[@]}"
+do
+	[[ ${reflector} =~ ^[0-9A-Za-z:][0-9A-Za-z.:_-]*$ ]] || { log_msg "ERROR" "Invalid reflector '${reflector}': must be an IP address or hostname. Exiting script."; exit 1; }
+done
+
 no_reflectors=${#reflectors[@]}
 
 # Check ping binary exists


### PR DESCRIPTION
## What

Validate every reflector against an IP-/hostname-shaped allowlist right after the list is finalised (local config + any `reflectors_url`), exiting with a clear error on a malformed entry — before any reflector reaches a pinger.

## Why — command injection on `pinger_method=irtt`

For `pinger_method=irtt` the reflector is interpolated into a shell command and executed: the gawk pinger builds `irtt client ... '<reflector>'` and runs it via `| getline`. A reflector containing a single quote breaks out of that quoting, so shell metacharacters become arbitrary command execution under the daemon (root on OpenWrt).

Reflectors aren't all operator-trusted: `reflectors_url` is fetched over plain HTTP (the code already `WARNING`s about the missing TLS), so a MITM can supply the list; and a hand-edited/templated config can carry a hostile entry. The other pinger methods pass the reflector as normal argv and merely fail on a bad entry, but validating once up front is the right place for all methods.

## How

One startup-time loop before `no_reflectors` is counted; regex `^[0-9A-Za-z][0-9A-Za-z.:_-]*$` accepts IPv4/IPv6/hostnames and rejects quotes, `;`, spaces, `$`, `()`. Zero steady-state cost, hard exit, matches the existing validation idiom.

`bash -n` clean; `shellcheck` adds no new findings. Running live here with no false rejections.
