### PR TITLE
mqtt-publisher: honour log_file_path_override + warn on missing logs/stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Also, for everyday use, consider disabling any unnecessary logging
 options, and especially: `output_summary_stats`,
 `output_processing_stats` and `output_load_stats`.
 
+Note that the MQTT publisher (`mqtt-publisher.sh`) is an exception: it
+derives its Home Assistant sensors from the `SUMMARY` (and `CPU`) log
+records, so any instance it should report needs `output_summary_stats=1`
+(and `output_cpu_stats=1` for the per-core CPU sensors); otherwise the
+sensors are created but never receive data.
+
 ## :stars: Stargazers <a name="stargazers"></a>
 
 [![Star History Chart](https://api.star-history.com/svg?repos=lynxthecat/cake-autorate&type=Date)](https://star-history.com/#lynxthecat/cake-autorate&Date)

--- a/mqtt-publisher.sh
+++ b/mqtt-publisher.sh
@@ -21,16 +21,18 @@ cleanup()
 {
     trap - INT TERM EXIT
     # Publish offline status for all instances on graceful shutdown
-    local log_file_path
+    local log_file_path log_dir
     shopt -s nullglob
-    for log_file_path in /var/log/cake-autorate.*.log; do
-        local instance="$(basename "${log_file_path}" | sed -E 's/^cake-autorate\.([^.]+)\.log$/\1/')"
-        mosquitto_pub \
-            -h "$MQTT_HOST" -p "$MQTT_PORT" \
-            -u "$MQTT_USER" -P "$MQTT_PASS" \
-            -r -q 1 \
-            -t "${BASE_MQTT_TOPIC}/${instance}/availability" \
-            -m "offline" 2>/dev/null || true
+    for log_dir in "${log_dirs[@]}"; do
+        for log_file_path in "${log_dir}"/cake-autorate.*.log; do
+            local instance="$(basename "${log_file_path}" | sed -E 's/^cake-autorate\.([^.]+)\.log$/\1/')"
+            mosquitto_pub \
+                -h "$MQTT_HOST" -p "$MQTT_PORT" \
+                -u "$MQTT_USER" -P "$MQTT_PASS" \
+                -r -q 1 \
+                -t "${BASE_MQTT_TOPIC}/${instance}/availability" \
+                -m "offline" 2>/dev/null || true
+        done
     done
     shopt -u nullglob
     for pid in "${publish_stats_pids[@]}"; do
@@ -211,15 +213,65 @@ publish_stats()
     done
 }
 
+# Discover where cake-autorate writes its logs, and sanity-check the config.
+#
+# cake-autorate honours log_file_path_override per instance, so globbing only
+# /var/log misses a relocated log and the publisher then silently does nothing.
+# Resolve the log dir(s) the same way cake-autorate does, from the configs next
+# to this script. The init.d launches ${SCRIPT_PREFIX}/mqtt-publisher.sh, so the
+# script's own directory is SCRIPT_PREFIX; CONFIG_PREFIX equals it unless the
+# install used a custom CAKE_AUTORATE_CONFIG_PREFIX (or Asuswrt-Merlin), whose
+# configs are then not auto-discovered (we fall back to /var/log + the warning).
+SCRIPT_PREFIX="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
+CONFIG_PREFIX="${SCRIPT_PREFIX}"
+
+declare -A seen_log_dir=()
+log_dirs=()
+any_stats_enabled=0
+shopt -s nullglob
+for config_path in "${CONFIG_PREFIX}"/config.*.sh; do
+    [[ -r ${config_path} ]] || continue
+    # Source defaults then this instance's config in a subshell (defaults first,
+    # then the override, matching cake-autorate) and read only the keys we need.
+    mapfile -t cfg_vals < <(
+        unset log_file_path_override output_summary_stats output_cpu_stats
+        # shellcheck source=defaults.sh
+        [[ -r ${SCRIPT_PREFIX}/defaults.sh ]] && . "${SCRIPT_PREFIX}/defaults.sh" 2>/dev/null
+        # shellcheck source=config.primary.sh
+        . "${config_path}" 2>/dev/null
+        printf '%s\n' "${log_file_path_override:-}" "${output_summary_stats:-0}" "${output_cpu_stats:-0}"
+    )
+    if [[ -n ${cfg_vals[0]} && -d ${cfg_vals[0]} ]]; then
+        log_dir="${cfg_vals[0]}"
+    else
+        log_dir="/var/log"
+    fi
+    [[ -n ${seen_log_dir[${log_dir}]:-} ]] || { seen_log_dir[${log_dir}]=1; log_dirs+=("${log_dir}"); }
+    [[ ${cfg_vals[1]} == 1 || ${cfg_vals[2]} == 1 ]] && any_stats_enabled=1
+done
+shopt -u nullglob
+# Fall back to the historical default if discovery turned up nothing.
+(( ${#log_dirs[@]} )) || log_dirs=("/var/log")
+
+if (( ! any_stats_enabled )); then
+    echo "WARNING: no cake-autorate config enables output_summary_stats=1 or output_cpu_stats=1 -- the Home Assistant sensors will be created via discovery but stay empty, because the SUMMARY/CPU log records the publisher reads are never produced. Enable output_summary_stats=1 (and/or output_cpu_stats=1) in the relevant config." >&2
+fi
+
 trap cleanup INT TERM EXIT
 
 publish_stats_pids=()
 
 shopt -s nullglob
-for log_file_path in /var/log/cake-autorate.*.log; do
-    ( publish_stats "$log_file_path" ) &
-    publish_stats_pids+=($!)
+for log_dir in "${log_dirs[@]}"; do
+    for log_file_path in "${log_dir}"/cake-autorate.*.log; do
+        ( publish_stats "$log_file_path" ) &
+        publish_stats_pids+=($!)
+    done
 done
 shopt -u nullglob
+
+if (( ${#publish_stats_pids[@]} == 0 )); then
+    echo "WARNING: no cake-autorate logs found (looked in: ${log_dirs[*]} for cake-autorate.*.log). Nothing to publish -- is cake-autorate running with logging enabled? If logs are relocated via log_file_path_override, ensure the instance config is readable next to this script so the path can be discovered." >&2
+fi
 
 wait


### PR DESCRIPTION
Part of the #379 mqtt-publisher cleanup — **Group 2** of the @ooonea / @bernhardberger split (the path/UX side; the Home Assistant payload + credential items in #379 stay with @bernhardberger). This is the "document/warn" half. Two fixes in `mqtt-publisher.sh` plus a README note:

## 1. Honour `log_file_path_override`

The publisher globbed a hardcoded `/var/log/cake-autorate.*.log` in both `cleanup()` and the fan-out loop, while cake-autorate writes to `${log_file_path_override}/cake-autorate.<instance>.log` when a config sets that override. So with a relocated log the publisher matched nothing and silently registered no instances.

It now discovers the log directories from the configs next to the script (`${SCRIPT_PREFIX}/config.*.sh`, sourced over `defaults.sh` the same way cake-autorate resolves each instance) and globs each, falling back to `/var/log`.

## 2. Warn instead of failing silently

- If **no** enabled config sets `output_summary_stats=1` or `output_cpu_stats=1`, warn at startup: discovery topics are still published but the sensors stay empty forever, because the publisher's data path keys off the `SUMMARY`/`CPU` log records — both off by default (the README even advised disabling `output_summary_stats`).
- If the glob matches **no** logs, warn that there's nothing to publish (covers "publisher started before cake-autorate", a relocated/undiscoverable path, or logging disabled).

## 3. Document the requirement (README)

The README advised disabling `output_summary_stats` for everyday use — the exact key the publisher needs — with no mention of the exception. Added a short note that the MQTT publisher needs `output_summary_stats=1` (and `output_cpu_stats=1` for the CPU sensors), right where the disabling advice is. Separate commit, one file.

## Notes / scope

- Resolution is a **union** of all discovered instance configs' log dirs (deduplicated), so multiple instances writing to different dirs all work; with no override it's byte-equivalent to the old `/var/log` glob.
- `CONFIG_PREFIX` is taken as `SCRIPT_PREFIX` (the init.d only bakes `%%SCRIPT_PREFIX%%`), which matches OpenWrt. A custom `CAKE_AUTORATE_CONFIG_PREFIX` (or Asuswrt-Merlin) splits them; those configs aren't auto-discovered and fall back to `/var/log` + the warning — flagging in case you'd rather thread `CONFIG_PREFIX` through the template.
- Configs are sourced in a `mapfile`/subshell with the read keys `unset` first, so only `log_file_path_override` / `output_summary_stats` / `output_cpu_stats` are consulted; the publisher already runs as root from the same directory and cake-autorate sources these same files. The `# shellcheck source=` directives mirror cake-autorate.sh.
- Deliberately untouched: the HA discovery contract, the averaged-emit / CPU-core payload, and the credential handling — the #379 items @bernhardberger owns.

`bash -n` clean; `shellcheck` clean under the repo `.shellcheckrc`; discovery logic unit-tested (override honoured, dirs deduped, stats detection, `/var/log` fallback).