### PR TITLE
fix: keep a monitor-only direction (adjust_*_shaper_rate=0) pinned at base (#377)

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -792,7 +792,7 @@ set_min_shaper_rates()
 	# calling the now-undefined name -> command-not-found -> intercept_stderr
 	# kills the daemon exactly when the clamp was wanted. Restore it as one
 	# function used by both sites.
-	shaper_rate_kbps[dl]=${min_dl_shaper_rate_kbps} shaper_rate_kbps[ul]=${min_ul_shaper_rate_kbps}
+	shaper_rate_kbps[dl]=${min_shaper_rate_kbps[dl]} shaper_rate_kbps[ul]=${min_shaper_rate_kbps[ul]}
 	set_shaper_rate "dl"
 	set_shaper_rate "ul"
 }
@@ -1294,6 +1294,25 @@ last_shaper_rate_kbps[dl]=0 last_shaper_rate_kbps[ul]=0 \
 interface[dl]=${dl_if} interface[ul]=${ul_if} \
 adjust_shaper_rate[dl]=${adjust_dl_shaper_rate} adjust_shaper_rate[ul]=${adjust_ul_shaper_rate} \
 dl_max_wire_packet_size_bits=0 ul_max_wire_packet_size_bits=0
+
+# A monitor-only direction (adjust_${direction}_shaper_rate=0) never has its
+# CAKE shaper changed, but its internal shaper_rate_kbps still divides into
+# load_percent. Collapse its runtime bounds onto base so that every existing
+# shaper_rate_kbps mutation site (the rate-update arms, the min/max clamp and
+# set_min_shaper_rates) lands the rate back on base, keeping load_percent
+# referenced to the real fixed rate without touching the rate-update hot path
+# (issue #377). base must therefore match the CAKE bandwidth actually fixed on
+# the interface -- noted at DEBUG for log forensics.
+if ((adjust_dl_shaper_rate == 0))
+then
+	min_shaper_rate_kbps[dl]=${base_dl_shaper_rate_kbps} max_shaper_rate_kbps[dl]=${base_dl_shaper_rate_kbps}
+	log_msg "DEBUG" "adjust_dl_shaper_rate=0 -- dl is monitor-only; load_percent[dl] is referenced to base_dl_shaper_rate_kbps (${base_dl_shaper_rate_kbps}), which should match the fixed download CAKE bandwidth on ${dl_if}."
+fi
+if ((adjust_ul_shaper_rate == 0))
+then
+	min_shaper_rate_kbps[ul]=${base_ul_shaper_rate_kbps} max_shaper_rate_kbps[ul]=${base_ul_shaper_rate_kbps}
+	log_msg "DEBUG" "adjust_ul_shaper_rate=0 -- ul is monitor-only; load_percent[ul] is referenced to base_ul_shaper_rate_kbps (${base_ul_shaper_rate_kbps}), which should match the fixed upload CAKE bandwidth on ${ul_if}."
+fi
 
 get_max_wire_packet_size_bits "${dl_if}" dl_max_wire_packet_size_bits
 get_max_wire_packet_size_bits "${ul_if}" ul_max_wire_packet_size_bits


### PR DESCRIPTION
A direction with `adjust_${direction}_shaper_rate=0` is monitor-only: `set_shaper_rate()` never issues a `tc` change for it, but its internal `shaper_rate_kbps` still walks the `[min, max]` range through the rate-update arms, the min/max clamp and `set_min_shaper_rates()`. Since `load_percent` is computed against `shaper_rate_kbps`, the reported load for the unmanaged direction is referenced to a phantom rate instead of the real, fixed CAKE bandwidth — with a fixed 200 Mbit/s download shaper and the internal rate drifted to the shipped default maximum, an empirically measured true 50% load was reported as 125%.

**v2, per review feedback: fix it in data, not control flow.** At startup, a monitor-only direction's *runtime* bounds collapse onto base (`min_shaper_rate_kbps[dir] = max_shaper_rate_kbps[dir] = base`). Every existing `shaper_rate_kbps` mutation site then lands the rate back on base:

- the min/max clamp is **untouched** — still one arithmetic block, byte-identical to master (this addresses the review comment favouring merged arithmetic blocks on the frequently-run path);
- the rate-update `for direction in dl ul` loop and its case arms are untouched;
- `set_min_shaper_rates()` now reads the runtime bounds arrays instead of the config scalars (cold path, idle/stall only; behaviour-identical for driven directions), so it too pins a monitor-only direction to base.

The config scalars are not modified: the startup config dump still shows what the user wrote, and the `min <= base <= max` startup validation (#387) runs on the scalars before this point and is unaffected.

A monitor-only direction's `base_${direction}_shaper_rate_kbps` must match the CAKE bandwidth actually fixed on the interface for `load_percent` to be meaningful; a one-shot DEBUG note records this at startup for log forensics.

Side effect worth noting: with the internal rate pinned, `set_shaper_rate()`'s early return silences the misleading SHAPER log lines master currently emits for a direction it never actually `tc`-changes.

`bash -n` clean; `shellcheck` identical to master (the 2 pre-existing SC2310 info notes, nothing new).

Fixes #377.