### PR TITLE
Add support for Debian/Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ more about cake-autorate. This is the history of changes.
 
 <!-- Zep7RkGZ52|NEW ENTRY MARKER, DO NOT REMOVE -->
 
+## [Unreleased]
+
+- Introduce support for running on Debian/Ubuntu
+
 ## 2026-03-04 - Version 3.5.0
 
 - Introduce MQTT data export functionality

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -78,6 +78,27 @@ required tools. To use it:
   sh /tmp/cake-autorate_setup.sh
   ```
 
+## Installation on Debian/Ubuntu
+
+Install prerequisites:
+
+```bash
+sudo apt install fping jq
+```
+
+Enable the service (assuming your WAN link is _wan1_):
+
+```bash
+sudo systemctl enable cake-autorate@wan1.service
+```
+
+Change the configuration and restart the service:
+
+```bash
+sudoedit /etc/cake-autorate/config.primary.sh
+sudo systemctl restart cake-autorate@wan1.service
+```
+
 ## Initial Configuration Steps (OpenWrt and Asus Merlin)
 
 - For a fresh install, you will need to undertake the following steps.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -78,6 +78,45 @@ required tools. To use it:
   sh /tmp/cake-autorate_setup.sh
   ```
 
+## Installation on Debian/Ubuntu
+
+- Set up [cake-on-wan](https://github.com/sbivol/cake-on-wan)
+
+- Install prerequisites:
+
+  ```bash
+  sudo apt install fping jq
+  ```
+
+- Install cake-autorate:
+
+  ```bash
+  wget -O /tmp/cake-autorate_setup.sh https://raw.githubusercontent.com/lynxthecat/cake-autorate/master/setup.sh
+  sudo sh /tmp/cake-autorate_setup.sh
+  ```
+
+- Enable the service (assuming your WAN link is _wan1_):
+
+  ```bash
+  sudo systemctl enable cake-autorate@wan1.service
+  ```
+
+- Change the configuration and restart the service:
+
+  ```bash
+  sudo cp /etc/cake-autorate/config.{primary,wan1}.sh
+  sudoedit /etc/cake-autorate/config.wan1.sh
+  sudo systemctl restart cake-autorate@wan1.service
+  ```
+
+For multiple WAN interfaces, enable additional services and duplicate the configuration:
+
+  ```bash
+  sudo cp /etc/cake-autorate/config.wan{1,2}.sh
+  sudoedit /etc/cake-autorate/config.wan2.sh
+  sudo systemctl enable --now cake-autorate@wan2.service
+  ```
+
 ## Initial Configuration Steps (OpenWrt and Asus Merlin)
 
 - For a fresh install, you will need to undertake the following steps.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ no reliable means to adjust the bandwidth on the fly.
 **cake-autorate** bridges this gap.
 
 **cake-autorate** presently supports installation on devices running
-on an [OpenWrt router](https://openwrt.org) or an
-[Asus Merlin router](https://www.asuswrt-merlin.net/).
+on an [OpenWrt router](https://openwrt.org), an
+[Asus Merlin router](https://www.asuswrt-merlin.net/), or an OS from the Debian family.
 
 ### Status
 
@@ -132,7 +132,7 @@ always testing for the true maximum as explained above).
 The baseline bandwidth is likely optimally either the minimum
 bandwidth or somewhere close thereto (e.g. the compromise bandwidth).
 
-## Installation on OpenWrt or Asus Merlin
+## Installation
 
 Read the installation instructions in the separate
 [INSTALLATION](./INSTALLATION.md) page.

--- a/cake-autorate@.service
+++ b/cake-autorate@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=cake-autorate for %i
+BindsTo=sys-subsystem-net-devices-%i.device
+After=sys-subsystem-net-devices-%i.device
+
+[Service]
+Environment="CAKE_AUTORATE_SCRIPT_PREFIX=/opt/cake-autorate"
+ExecStartPre=/opt/cake-autorate/ifb-setup.sh %i
+ExecStart=/opt/cake-autorate/launcher.sh
+Restart=on-failure
+RestartMode=direct
+RestartSec=5
+TimeoutStopSec=10
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/cake-autorate@.service
+++ b/cake-autorate@.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=cake-autorate for %I
+BindsTo=sys-subsystem-net-devices-%i.device
+After=sys-subsystem-net-devices-%i.device
+
+[Service]
+AmbientCapabilities=CAP_NET_ADMIN
+AmbientCapabilities=CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_RAW
+Environment="CAKE_AUTORATE_SCRIPT_PREFIX=/opt/cake-autorate" "CAKE_AUTORATE_CONFIG_PREFIX=/etc/cake-autorate"
+ExecStart=/opt/cake-autorate/cake-autorate.sh ${CAKE_AUTORATE_CONFIG_PREFIX}/config.%I.sh
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+Restart=on-failure
+RestartMode=direct
+RestartSec=5
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictAddressFamilies=AF_NETLINK
+RestrictAddressFamilies=AF_UNIX
+RuntimeDirectory=cake-autorate
+StandardOutput=journal
+TimeoutStopSec=15
+
+[Install]
+WantedBy=multi-user.target

--- a/ifb-setup.sh
+++ b/ifb-setup.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Set up the IFB interface and TC
+
+set -eu
+
+wan="${1:-}"
+
+if [ -z "${wan}" ]
+then
+	echo "No interface name provided"
+	exit 1
+fi
+
+if ip link show ${wan}
+then
+	# Upload
+	sudo tc qdisc replace dev ${wan} root cake bandwidth 40mbit
+
+	# Download
+	if ! ip link show ifb4${wan}
+	then
+		sudo ip link add name ifb4${wan} type ifb
+	fi
+	sudo tc qdisc del dev ${wan} ingress 2> /dev/null || :
+	sudo tc qdisc add dev ${wan} handle ffff: ingress
+	sudo tc qdisc del dev ifb4${wan} root 2> /dev/null || :
+	sudo tc qdisc add dev ifb4${wan} root cake bandwidth 40mbit besteffort
+	sudo ip link set ifb4${wan} up
+	sudo tc filter add dev ${wan} parent ffff: matchall action mirred egress redirect dev ifb4${wan}
+
+else
+	exit 1
+fi
+
+# vim: noet ts=4

--- a/setup.sh
+++ b/setup.sh
@@ -32,7 +32,7 @@ main() {
 	set -eu
 
 	# Setup dependencies to check for
-	DEPENDENCIES="jsonfilter tar grep cmp mktemp bash"
+	DEPENDENCIES="tar grep cmp mktemp bash"
 
 	# Set up remote locations and branch
 	BRANCH="${CAKE_AUTORATE_BRANCH:-${2-master}}"
@@ -62,8 +62,22 @@ main() {
 		if [ "${x}" = "openwrt" ]
 		then
 			MY_OS=openwrt
+			DEPENDENCIES="jsonfilter ${DEPENDENCIES}"
 			[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/root/cake-autorate
 			[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/root/cake-autorate
+			break
+		fi
+	done
+
+	# Check if OS is part of the Debian family
+	for x in ${ID_LIKE:-}
+	do
+		if [ "${x}" = "debian" ]
+		then
+			MY_OS=debian
+			DEPENDENCIES="jq ${DEPENDENCIES}"
+			[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/opt/cake-autorate
+			[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/etc/cake-autorate
 			break
 		fi
 	done
@@ -72,6 +86,7 @@ main() {
 	if [ "$(uname -o)" = "ASUSWRT-Merlin" ]
 	then
 		MY_OS=asuswrt
+		DEPENDENCIES="jsonfilter ${DEPENDENCIES}"
 		[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/jffs/scripts/cake-autorate
 		[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/jffs/configs/cake-autorate
 	fi
@@ -79,7 +94,7 @@ main() {
 	# If we are not running on OpenWRT or ASUSWRT-Merlin, exit
 	if [ "${MY_OS}" = "unknown" ]
 	then
-		printf "This script requires OpenWrt or ASUSWRT-Merlin\n" >&2
+		printf "The current operating system is not supported\n" >&2
 		return 1
 	fi
 
@@ -127,7 +142,13 @@ main() {
 
 	# Get the latest commit to download
 	[ -z "${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT:-}" ] && \
-		commit=$(download_url "${API_URL}" | jsonfilter -e @.sha) || \
+		if [ "${MY_OS}" = "openwrt" ] || [ "${MY_OS}" = "asuswrt" ]
+		then
+			JSON_CMD="jsonfilter -e @.sha"
+		else
+			JSON_CMD="jq -r .sha"
+		fi
+		commit=$(download_url "${API_URL}" | ${JSON_CMD}) || \
 		commit="${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT}"
 	if [ -z "${commit:-}" ];
 	then
@@ -239,6 +260,12 @@ main() {
 		chmod +x /etc/init.d/mqtt-publisher
 	fi
 
+	if [ "${MY_OS}" = "debian" ]
+	then
+		mv "${tmp}/cake-autorate@.service" "/etc/systemd/system/"
+		mv "${tmp}/ifb-setup.sh" "${SCRIPT_PREFIX}/"
+	fi
+
 	# Get version and generate a file containing version information
 	cd "${SCRIPT_PREFIX}"
 	version=$(grep -m 1 ^cake_autorate_version= "${SCRIPT_PREFIX}/cake-autorate.sh" | cut -d= -f2 | cut -d'"' -f2)
@@ -266,6 +293,10 @@ main() {
 			printf '%s\n' "   echo ${SCRIPT_PREFIX}/launcher.sh > /opt/etc/init.d/S99cake-autorate"
 			printf '%s\n' "   chmod +x /opt/etc/init.d/S99cake-autorate"
 			printf '%s\n\n' "See also: https://github.com/RMerl/asuswrt-merlin.ng/wiki/User-scripts"
+			;;
+		"debian")
+			printf '%s\n' "Run as a service with:"
+			printf '%s\n\n' "   systemctl enable --now cake-autorate@<interface>.service"
 			;;
 		*)
 			;;

--- a/setup.sh
+++ b/setup.sh
@@ -32,7 +32,7 @@ main() {
 	set -eu
 
 	# Setup dependencies to check for
-	DEPENDENCIES="jsonfilter tar grep cmp mktemp bash"
+	DEPENDENCIES="tar grep cmp mktemp bash"
 
 	# Set up remote locations and branch
 	BRANCH="${CAKE_AUTORATE_BRANCH:-${2-master}}"
@@ -62,8 +62,22 @@ main() {
 		if [ "${x}" = "openwrt" ]
 		then
 			MY_OS=openwrt
+			DEPENDENCIES="jsonfilter ${DEPENDENCIES}"
 			[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/root/cake-autorate
 			[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/root/cake-autorate
+			break
+		fi
+	done
+
+	# Check if OS is part of the Debian family
+	for x in ${ID_LIKE:-}
+	do
+		if [ "${x}" = "debian" ]
+		then
+			MY_OS=debian
+			DEPENDENCIES="jq ${DEPENDENCIES}"
+			[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/opt/cake-autorate
+			[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/etc/cake-autorate
 			break
 		fi
 	done
@@ -72,6 +86,7 @@ main() {
 	if [ "$(uname -o)" = "ASUSWRT-Merlin" ]
 	then
 		MY_OS=asuswrt
+		DEPENDENCIES="jsonfilter ${DEPENDENCIES}"
 		[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/jffs/scripts/cake-autorate
 		[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/jffs/configs/cake-autorate
 	fi
@@ -79,7 +94,7 @@ main() {
 	# If we are not running on OpenWRT or ASUSWRT-Merlin, exit
 	if [ "${MY_OS}" = "unknown" ]
 	then
-		printf "This script requires OpenWrt or ASUSWRT-Merlin\n" >&2
+		printf "The current operating system is not supported\n" >&2
 		return 1
 	fi
 
@@ -127,7 +142,13 @@ main() {
 
 	# Get the latest commit to download
 	[ -z "${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT:-}" ] && \
-		commit=$(download_url "${API_URL}" | jsonfilter -e @.sha) || \
+		if [ "${MY_OS}" = "openwrt" ] || [ "${MY_OS}" = "asuswrt" ]
+		then
+			JSON_CMD="jsonfilter -e @.sha"
+		else
+			JSON_CMD="jq -r .sha"
+		fi
+		commit=$(download_url "${API_URL}" | ${JSON_CMD}) || \
 		commit="${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT}"
 	if [ -z "${commit:-}" ];
 	then
@@ -239,6 +260,11 @@ main() {
 		chmod +x /etc/init.d/mqtt-publisher
 	fi
 
+	if [ "${MY_OS}" = "debian" ]
+	then
+		mv "${tmp}/cake-autorate@.service" "/etc/systemd/system/"
+	fi
+
 	# Get version and generate a file containing version information
 	cd "${SCRIPT_PREFIX}"
 	version=$(grep -m 1 ^cake_autorate_version= "${SCRIPT_PREFIX}/cake-autorate.sh" | cut -d= -f2 | cut -d'"' -f2)
@@ -266,6 +292,10 @@ main() {
 			printf '%s\n' "   echo ${SCRIPT_PREFIX}/launcher.sh > /opt/etc/init.d/S99cake-autorate"
 			printf '%s\n' "   chmod +x /opt/etc/init.d/S99cake-autorate"
 			printf '%s\n\n' "See also: https://github.com/RMerl/asuswrt-merlin.ng/wiki/User-scripts"
+			;;
+		"debian")
+			printf '%s\n' "Run as a service with:"
+			printf '%s\n\n' "   systemctl enable --now cake-autorate@<interface>.service"
 			;;
 		*)
 			;;

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -36,6 +36,18 @@ main() {
 		fi
 	done
 
+	# Check if OS is part of the Debian family
+	for x in ${ID_LIKE:-}
+	do
+		if [ "${x}" = "debian" ]
+		then
+			MY_OS=debian
+			[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/opt/cake-autorate
+			[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/etc/cake-autorate
+			break
+		fi
+	done
+
 	# Check if OS is ASUSWRT-Merlin
 	if [ "$(uname -o)" = "ASUSWRT-Merlin" ]
 	then
@@ -47,21 +59,30 @@ main() {
 	# If we are not running on OpenWRT or ASUSWRT-Merlin, exit
 	if [ "${MY_OS}" = "unknown" ]
 	then
-		printf "This script requires OpenWrt or ASUSWRT-Merlin\n" >&2
+		printf "The current operating system is not supported\n" >&2
 		return 1
 	fi
 
-	# Stop cake-autorate before continueing
-	if [ -x /etc/init.d/cake-autorate ]
+	if [ "${MY_OS}" = "asuswrt" ] || [ "${MY_OS}" = "openwrt" ]
 	then
-		/etc/init.d/cake-autorate stop || :
+		# Stop cake-autorate before continuing
+		if [ -x /etc/init.d/cake-autorate ]
+		then
+			/etc/init.d/cake-autorate stop || :
+		fi
+		if [ -x /etc/init.d/mqtt-publisher ]
+		then
+			/etc/init.d/mqtt-publisher stop || :
+		fi
+		rm -f /etc/init.d/cake-autorate /etc/rc.d/*cake-autorate
+		rm -f /etc/init.d/mqtt-publisher /etc/rc.d/*mqtt-publisher
 	fi
-	if [ -x /etc/init.d/mqtt-publisher ]
+
+	if [ "${MY_OS}" = "debian" ]
 	then
-		/etc/init.d/mqtt-publisher stop || :
+		systemctl disable --now cake-autorate@.service || :
+		rm -f /etc/systemd/system/cake-autorate@.service
 	fi
-	rm -f /etc/init.d/cake-autorate /etc/rc.d/*cake-autorate
-	rm -f /etc/init.d/mqtt-publisher /etc/rc.d/*mqtt-publisher
 
 	# Check if an instance of cake-autorate is already running and exit if so
 	if [ -d /var/run/cake-autorate ]
@@ -100,7 +121,7 @@ main() {
 
 	# remove current program files from the cake-autorate directory
 	cd "${SCRIPT_PREFIX}"
-	files="cake-autorate.sh defaults.sh launcher.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh"
+	files="cake-autorate.sh defaults.sh ifb-setup.sh launcher.sh lib.sh mqtt-publisher.sh setup.sh uninstall.sh"
 	for file in ${files}
 	do
 		rm -f "${file}"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -36,6 +36,18 @@ main() {
 		fi
 	done
 
+	# Check if OS is part of the Debian family
+	for x in ${ID_LIKE:-}
+	do
+		if [ "${x}" = "debian" ]
+		then
+			MY_OS=debian
+			[ -z "${SCRIPT_PREFIX}" ] && SCRIPT_PREFIX=/opt/cake-autorate
+			[ -z "${CONFIG_PREFIX}" ] && CONFIG_PREFIX=/etc/cake-autorate
+			break
+		fi
+	done
+
 	# Check if OS is ASUSWRT-Merlin
 	if [ "$(uname -o)" = "ASUSWRT-Merlin" ]
 	then
@@ -47,21 +59,30 @@ main() {
 	# If we are not running on OpenWRT or ASUSWRT-Merlin, exit
 	if [ "${MY_OS}" = "unknown" ]
 	then
-		printf "This script requires OpenWrt or ASUSWRT-Merlin\n" >&2
+		printf "The current operating system is not supported\n" >&2
 		return 1
 	fi
 
-	# Stop cake-autorate before continueing
-	if [ -x /etc/init.d/cake-autorate ]
+	if [ "${MY_OS}" = "asuswrt" ] || [ "${MY_OS}" = "openwrt" ]
 	then
-		/etc/init.d/cake-autorate stop || :
+		# Stop cake-autorate before continuing
+		if [ -x /etc/init.d/cake-autorate ]
+		then
+			/etc/init.d/cake-autorate stop || :
+		fi
+		if [ -x /etc/init.d/mqtt-publisher ]
+		then
+			/etc/init.d/mqtt-publisher stop || :
+		fi
+		rm -f /etc/init.d/cake-autorate /etc/rc.d/*cake-autorate
+		rm -f /etc/init.d/mqtt-publisher /etc/rc.d/*mqtt-publisher
 	fi
-	if [ -x /etc/init.d/mqtt-publisher ]
+
+	if [ "${MY_OS}" = "debian" ]
 	then
-		/etc/init.d/mqtt-publisher stop || :
+		systemctl disable --now cake-autorate@.service || :
+		rm -f /etc/systemd/system/cake-autorate@.service
 	fi
-	rm -f /etc/init.d/cake-autorate /etc/rc.d/*cake-autorate
-	rm -f /etc/init.d/mqtt-publisher /etc/rc.d/*mqtt-publisher
 
 	# Check if an instance of cake-autorate is already running and exit if so
 	if [ -d /var/run/cake-autorate ]


### PR DESCRIPTION
This adds support for running cake-autorate on Debian and related distributions.

I have been running cake-autorate on Ubuntu Server for a year and am willing to maintain support for this OS family going forward.