### PR TITLE
startup: check for a conflicting instance before rotating the log

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -996,18 +996,11 @@ else
 	log_file_path="/var/log/cake-autorate${instance_id:+.${instance_id}}.log"
 fi
 
-rotate_log_file
-
-# save stderr fd, redirect stderr to intercept_stderr
-# intercept_stderr sends stderr to log_msg and exits cake-autorate
-exec {original_stderr_fd}>&2 2> >(intercept_stderr)
-
-proc_pids['intercept_stderr']=${!}
-
-log_msg "SYSLOG" "Starting cake-autorate with PID: ${BASHPID} and config: ${config_path}"
-
 # ${run_path}/ is used to store temporary files
-# it should not exist on startup so if it does exit, else create the directory
+# it should not exist on startup so if it does exit, else create the directory.
+# This must run BEFORE rotate_log_file: a redundant start of an already-running
+# instance has to exit *without* rotating (truncating) the log file the running
+# instance is still writing to, so the conflicting-instance check comes first.
 if [[ -d ${run_path} ]]
 then
 	if running_main_pid=$(get_running_main_pid_for_run_path "${run_path}")
@@ -1023,6 +1016,16 @@ then
 else
 	( umask 077 && mkdir -p "${run_path}" )
 fi
+
+rotate_log_file
+
+# save stderr fd, redirect stderr to intercept_stderr
+# intercept_stderr sends stderr to log_msg and exits cake-autorate
+exec {original_stderr_fd}>&2 2> >(intercept_stderr)
+
+proc_pids['intercept_stderr']=${!}
+
+log_msg "SYSLOG" "Starting cake-autorate with PID: ${BASHPID} and config: ${config_path}"
 
 proc_pids['main']=${BASHPID}
 


### PR DESCRIPTION
Split out from the closed #373, which conflated two unrelated fixes. This is the log-rotation half; the config-bounds half is a separate PR.

### The bug

The running-instance check (present before #369, which strengthened it with the run-token validation) runs *after* `rotate_log_file`. So starting a redundant second instance of an already-running config rotates/truncates the shared log file first, and only then detects the conflict and exits — corrupting the log of the instance that is legitimately running.

### The fix

Move the `run_path` conflicting-instance check ahead of `rotate_log_file` (and ahead of the stderr-intercept setup and the "Starting" SYSLOG line). A redundant start now exits without touching the running instance's log or spawning `intercept_stderr`; the log is only rotated once we know we are actually going to start.

Pure reordering — the check, the rotate and the redirect blocks are unchanged, only their order is. `bash -n` clean; `shellcheck -x`: same findings as `master` (only their line numbers shift with the move).