### PR TITLE
cleanup: drop stale *_pinger entries from proc_pids before the final sweep (#378)

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -129,6 +129,17 @@ cleanup_and_killall()
 	then
 		unset "proc_pids[intercept_stderr]"
 	fi
+
+	# The pingers were already terminated above via pinger_pids; their entries in
+	# proc_pids (irtt_N_pinger / tsping_pinger / fping_pinger / ping_N_pinger) are
+	# now stale, and after the grace sleep those PIDs may have been recycled to
+	# unrelated processes. Drop them so the sweep below only signals processes
+	# that genuinely remain.
+	for proc_pid in "${!proc_pids[@]}"
+	do
+		[[ ${proc_pid} == *_pinger ]] && unset "proc_pids[${proc_pid}]"
+	done
+
 	terminate "${proc_pids[*]}"
 
 	# restore original stderr, and terminate intercept_stderr


### PR DESCRIPTION
Addresses point 2 of #378 (stale pinger PIDs never cleared from `proc_pids`). Point 1 (signal coalescing) is left alone, per @rany2's read that it is a non-issue.

The pingers are terminated early in `cleanup_and_killall` via `pinger_pids`, but their entries in `proc_pids` (`irtt_N_pinger` / `tsping_pinger` / `fping_pinger` / `ping_N_pinger`) are never removed. The final `terminate "${proc_pids[*]}"` then re-signals those PIDs — and because it runs *after* the one-second grace sleep, a dead pinger's PID may by then have been recycled to an unrelated process, which would be signalled instead.

Prune the `*_pinger` keys alongside the existing `main` / `intercept_stderr` unsets, right before the sweep (the "unsetting" you suggested), using the same iteration form as `export_proc_pids`. `bash -n` clean; `shellcheck -x` identical to `master`.
