### PR TITLE
uninstall: match setup.sh's os-release sourcing idiom (#379)

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,9 +22,13 @@ main() {
 
 	# Check if OS is OpenWRT or derivative
 	unset ID_LIKE
-	# We do `set +/-e` here because in some Busybox sh versions
-	# `. /not_found || true` doesn't do anything
-	set +e; . /etc/os-release 2>/dev/null; set -e
+
+	# The following formulations seem to be problematic for some sh versions:
+	# - `. /not_found || true`
+	# - set +e; . /etc/os-release 2>/dev/null; set -e
+	# but this seems to work OK:
+	[ -e "/etc/os-release" ] && . /etc/os-release
+
 	for x in ${ID_LIKE:-}
 	do
 		if [ "${x}" = "openwrt" ]


### PR DESCRIPTION
The `uninstall.sh` os-release consistency fix from #379 (item 4 of the work split agreed in that thread). It was originally going to be folded into #368, but that PR is now closed, so here it is standalone.

`setup.sh`'s own comment flags `set +e; . /etc/os-release 2>/dev/null; set -e` as problematic on some Busybox `sh` versions and switched to `[ -e "/etc/os-release" ] && . /etc/os-release`. `uninstall.sh` still carried the flagged form; this aligns it so both installer scripts source os-release the same, portable way. The new block is byte-identical to `setup.sh`'s.

`sh -n` clean; `shellcheck` reports only the pre-existing SC1091 info on the os-release source — the same finding `setup.sh` carries.