### PR TITLE
mqtt-publisher: keep the broker password off the command line (#379)

### DIFF
--- a/mqtt-publisher.sh
+++ b/mqtt-publisher.sh
@@ -26,9 +26,8 @@ cleanup()
     for log_dir in "${log_dirs[@]}"; do
         for log_file_path in "${log_dir}"/cake-autorate.*.log; do
             local instance="$(basename "${log_file_path}" | sed -E 's/^cake-autorate\.([^.]+)\.log$/\1/')"
-            mosquitto_pub \
+            XDG_CONFIG_HOME="${mqtt_config_dir}" mosquitto_pub \
                 -h "$MQTT_HOST" -p "$MQTT_PORT" \
-                -u "$MQTT_USER" -P "$MQTT_PASS" \
                 -r -q 1 \
                 -t "${BASE_MQTT_TOPIC}/${instance}/availability" \
                 -m "offline" 2>/dev/null || true
@@ -38,6 +37,8 @@ cleanup()
     for pid in "${publish_stats_pids[@]}"; do
         kill -- -"$pid" 2>/dev/null || true
     done
+    # after the shutdown publishes above, which still need to authenticate
+    rm -rf "${mqtt_config_dir}"
     exit 0
 }
 
@@ -47,9 +48,8 @@ publish_config()
     local object_id="$2"
     local payload="$3"
 
-    mosquitto_pub \
+    XDG_CONFIG_HOME="${mqtt_config_dir}" mosquitto_pub \
         -h "$MQTT_HOST" -p "$MQTT_PORT" \
-        -u "$MQTT_USER" -P "$MQTT_PASS" \
         -r -q 1 \
         -t "$DISC_PREFIX/sensor/$device_id/$object_id/config" \
         -m "$payload"
@@ -115,9 +115,8 @@ publish_stats()
     while true; do
         # Publish birth message (retained) to mark sensors as available
         # on initial connect and after any reconnect.
-        mosquitto_pub \
+        XDG_CONFIG_HOME="${mqtt_config_dir}" mosquitto_pub \
             -h "$MQTT_HOST" -p "$MQTT_PORT" \
-            -u "$MQTT_USER" -P "$MQTT_PASS" \
             -r -q 1 \
             -t "$AVAIL_TOPIC" \
             -m "online"
@@ -200,9 +199,8 @@ publish_stats()
                 fflush("")
             }
         }
-        ' | mosquitto_pub \
+        ' | XDG_CONFIG_HOME="${mqtt_config_dir}" mosquitto_pub \
             -h "$MQTT_HOST" -p "$MQTT_PORT" \
-            -u "$MQTT_USER" -P "$MQTT_PASS" \
             -t "$MQTT_TOPIC" -l -q 1 \
             --will-topic "$AVAIL_TOPIC" \
             --will-payload "offline" \
@@ -255,6 +253,21 @@ shopt -u nullglob
 
 if (( ! any_stats_enabled )); then
     echo "WARNING: no cake-autorate config enables output_summary_stats=1 or output_cpu_stats=1 -- the Home Assistant sensors will be created via discovery but stay empty, because the SUMMARY/CPU log records the publisher reads are never produced. Enable output_summary_stats=1 (and/or output_cpu_stats=1) in the relevant config." >&2
+fi
+
+# Keep the broker credentials off the command line.
+#
+# mosquitto_pub exposes -u/-P in /proc/<pid>/cmdline, and the streaming
+# publisher below is long-lived, so the password would otherwise be readable
+# by every process on the box for as long as this runs. mosquitto's clients
+# read a default config file at $XDG_CONFIG_HOME/mosquitto_pub and feed its
+# lines through the same option parser as argv, so the credentials can travel
+# there instead. That path exists in the mosquitto 2.0.x OpenWrt ships; the -o
+# options-file flag would need 2.1.0. mktemp -d gives us a 0700 directory and
+# the trap below removes it.
+mqtt_config_dir=$(mktemp -d) || { echo "ERROR: failed to create a private directory for the MQTT credentials" >&2; exit 1; }
+if [[ -n ${MQTT_USER} || -n ${MQTT_PASS} ]]; then
+    ( umask 077; printf '%s\n' "-u ${MQTT_USER}" "-P ${MQTT_PASS}" > "${mqtt_config_dir}/mosquitto_pub" )
 fi
 
 trap cleanup INT TERM EXIT


### PR DESCRIPTION
Addresses the security item from #379: the broker password was passed as `-P "$MQTT_PASS"` at all four `mosquitto_pub` call sites, so it sat in `/proc/<pid>/cmdline` for any process on the box to read. The streaming publisher uses `-l` and is long-lived, so the exposure was continuous rather than momentary.

### Mechanism

Neither of the two options named in #379 works here, as discussed in [this comment](https://github.com/lynxthecat/cake-autorate/issues/379#issuecomment-5083386625): `--pw-file` has never existed in any mosquitto client, and `-o` needs 2.1.0 while OpenWrt ships 2.0.22. What 2.0.22 does have is the client's own default config file — `client_config_load()` reads `$XDG_CONFIG_HOME/mosquitto_pub` and parses its lines with the same option parser as argv (`client/client_shared.c:291-321`, with `-P`/`--pw` at :862 and `-u`/`--username` at :1097).

So: `mktemp -d` (0700), the two options written under `umask 077`, and the four call sites prefixed with `XDG_CONFIG_HOME=` instead of carrying the credentials. `cleanup()` removes the directory *after* the shutdown `offline` publishes, which still need to authenticate. No new dependency, no version floor above what OpenWrt already ships.

### Behaviour change worth naming

With `MQTT_USER` and `MQTT_PASS` both empty, no credential file is written and neither flag is passed, where previously two empty strings were. Anonymous brokers should be unaffected in practice, but it is a real difference and I would rather flag it than have it found later.

### Verification

Against a local broker with `allow_anonymous false` and a password file, running this actual script against a stub deployment (config with `log_file_path_override`, one `cake-autorate.*.log`):

- the publisher authenticates and the retained `cake-autorate/test/availability online` arrives — so the credentials are being read from the file
- `/proc/<pid>/cmdline` of the live `-l` publisher: `mosquitto_pub -h 127.0.0.1 -p 18831 -t cake-autorate/test -l -q 1 --will-topic … --will-retain` — no password
- the credential file lands `0600`
- after shutdown the directory is gone

`bash -n` clean; `shellcheck -S style` reports only the two pre-existing `SC1091` source-not-followed infos.

### Scope

This is only the argv half of group 1 from #379. The clean-exit `offline` publish and group 3 remain with @bernhardberger, per the split agreed in that thread.

One thing this does *not* fix, noted in #379: `MQTT_PASS` is still a literal in `mqtt-publisher.sh`, which installs `0755`. Getting it off argv removes the continuous `ps` exposure, but the secret living in a world-readable script is a separate question for whoever owns the install path.
