### PR TITLE
shaper: detect a cake_mq root qdisc instead of assuming cake (#353)

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -754,11 +754,11 @@ set_shaper_rate()
 
 	(( shaper_rate_kbps[${direction}] != last_shaper_rate_kbps[${direction}] )) || return
 
-	((output_cake_changes)) && log_msg "SHAPER" "tc qdisc change root dev ${interface[${direction}]} cake bandwidth ${shaper_rate_kbps[${direction}]}Kbit"
+	((output_cake_changes)) && log_msg "SHAPER" "tc qdisc change root dev ${interface[${direction}]} ${qdisc_kind[${direction}]} bandwidth ${shaper_rate_kbps[${direction}]}Kbit"
 
 	if ((adjust_shaper_rate[${direction}]))
 	then
-		tc qdisc change root dev "${interface[${direction}]}" cake bandwidth "${shaper_rate_kbps[${direction}]}Kbit" 2> /dev/null
+		tc qdisc change root dev "${interface[${direction}]}" "${qdisc_kind[${direction}]}" bandwidth "${shaper_rate_kbps[${direction}]}Kbit" 2> /dev/null
 	else
 		((output_cake_changes)) && log_msg "DEBUG" "adjust_${direction}_shaper_rate set to 0 in config, so skipping the corresponding tc qdisc change call."
 	fi
@@ -795,6 +795,26 @@ set_min_shaper_rates()
 	shaper_rate_kbps[dl]=${min_shaper_rate_kbps[dl]} shaper_rate_kbps[ul]=${min_shaper_rate_kbps[ul]}
 	set_shaper_rate "dl"
 	set_shaper_rate "ul"
+}
+
+get_root_qdisc_kind()
+{
+	# cake is normally the root qdisc, but on a multi-queue interface it can be
+	# deployed as cake_mq, which owns the root and holds a per-queue cake under
+	# it (sqm-scripts selects it when num_queues > 1). 'tc qdisc change' matches
+	# on the root qdisc's own kind, so asking for 'cake' against a cake_mq root
+	# returns "Invalid qdisc name" - and because the call below sends stderr to
+	# /dev/null and ignores the exit status, cake-autorate would go on logging
+	# SHAPER lines while shaping nothing at all. Detect the kind once at startup
+	# and use whatever is actually there.
+	#
+	# Anything unrecognised falls back to 'cake', so behaviour on a conventional
+	# setup is byte-identical to before.
+
+	local direction=${1} # 'dl' or 'ul'
+
+	qdisc_kind[${direction}]=cake
+	[[ $(tc qdisc show root dev "${interface[${direction}]:?}") =~ ^qdisc[[:space:]]+(cake_mq|cake)[[:space:]] ]] && qdisc_kind[${direction}]=${BASH_REMATCH[1]}
 }
 
 get_max_wire_packet_size_bits()
@@ -1271,6 +1291,7 @@ base_shaper_rate_kbps \
 min_shaper_rate_kbps \
 max_shaper_rate_kbps \
 interface \
+qdisc_kind \
 adjust_shaper_rate \
 avg_owd_delta_us \
 avg_owd_delta_max_adjust_up_thr_us \
@@ -1313,6 +1334,9 @@ then
 	min_shaper_rate_kbps[ul]=${base_ul_shaper_rate_kbps} max_shaper_rate_kbps[ul]=${base_ul_shaper_rate_kbps}
 	log_msg "DEBUG" "adjust_ul_shaper_rate=0 -- ul is monitor-only; load_percent[ul] is referenced to base_ul_shaper_rate_kbps (${base_ul_shaper_rate_kbps}), which should match the fixed upload CAKE bandwidth on ${ul_if}."
 fi
+
+get_root_qdisc_kind "dl"
+get_root_qdisc_kind "ul"
 
 get_max_wire_packet_size_bits "${dl_if}" dl_max_wire_packet_size_bits
 get_max_wire_packet_size_bits "${ul_if}" ul_max_wire_packet_size_bits


### PR DESCRIPTION
Closes the gap reported in #353. @lynxthecat asked me in that thread whether I saw a good way to address it; this is the shape I proposed there, now written out.

### The failure mode

`set_shaper_rate()` hardcodes `cake` in its `tc qdisc change root` call. If the root qdisc is `cake_mq`, the kernel rejects the change with `Invalid qdisc name` — but the call sends stderr to `/dev/null` and its exit status is never checked, so cake-autorate keeps emitting `SHAPER` log lines while shaping nothing. It fails silently, which is worse than failing loudly: from the logs everything looks fine.

This is reachable today, not hypothetical: sqm-scripts picks `cake_mq` whenever `USE_MQ=1` and the device has more than one queue (`functions.sh:966-968`), and OpenWrt carries the kernel side in `backport-6.12` (`700-02`..`700-07`) plus the iproute2 side in `001-1-tc-cake-add-cake_mq-support`. Configuring the `cake_mq` instance directly and letting the config reach the sub-qdiscs is the designed behaviour — `700-04` is literally "Share config across cake_mq sub-qdiscs".

### The change

~15 lines. `get_root_qdisc_kind()` reads `tc qdisc show root dev <if>` once per direction at startup and stores the kind in a new `qdisc_kind[dl|ul]`; `set_shaper_rate()` uses that instead of the literal. Anything unrecognised — `htb`, `noqueue`, empty output, a leaf line — falls back to `cake`, so a conventional setup is byte-identical to today. No per-iteration cost, no new config knob.

### What I tested, and what I could not

Tested:

- 6/6 detection cases against real `tc` output strings: `cake_mq` root → `cake_mq`; `cake` root, `htb` root, `noqueue`, a `parent 1:1` leaf line, and empty output → `cake`
- against a **real** `tc qdisc show root`, in a network namespace with a dummy interface: a genuine `cake` root is detected as `cake`; `fq_codel` and `htb` roots fall back to `cake`
- `bash -n` clean, `shellcheck -S warning` reports nothing on the new lines

Not tested, and this is the part that needs someone with the hardware: **I have no cake_mq-capable box**, so I have not observed an actual `tc qdisc change root dev <if> cake_mq bandwidth <X>` taking effect end to end. The detection is verified; that the subsequent rate change propagates to the sub-qdiscs rests on reading `700-04`/`701-02` rather than on my having seen it work.

Marking this a draft for exactly that reason. @Snuupy, @CHC383 — you raised #353 and suggested the `grep -q cake_mq` approach; if either of you can run this on a multi-queue setup with `USE_MQ=1` and confirm the shaper actually tracks, I will flip it out of draft. If it turns out `change` on a `cake_mq` root needs different handling, better to find that now than after merge.
