### PR TITLE
fix: reject non-numeric RTT samples (a clock step mid-ping kills the daemon)

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1464,7 +1464,15 @@ do
 					fi
 					;;
 				fping)
-					if ((${#command[@]} == 12))
+					# fping reports a negative RTT when the clock steps backwards
+					# mid-ping: it prints such a value rather than clamping it, and
+					# 10#${rtt_us//.} cannot represent a negative, so the arithmetic
+					# error kills the main loop. Reject any RTT token carrying a
+					# character outside [0-9.] — a glob class check, not a regex,
+					# since [[ =~ ]] recompiles the ERE on every sample.
+					# The ping arm needs no equivalent: iputils clamps a backward
+					# step to zero instead of reporting it.
+					if ((${#command[@]} == 12)) && [[ ${command[6]} != *[!0-9.]* ]]
 					then
 						timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} rtt_ms=${command[6]} reflector_response=1
 					fi


### PR DESCRIPTION
On the first boot after an OS upgrade, cake-autorate died 35 seconds in and my WAN ran unshaped until I restarted it by hand. What made it worse is that systemd saw a clean exit — "Deactivated successfully" — so no `Restart=` policy would have caught it. The shaper was just quietly gone.

The daemon log and chronyd, in the same second:

```
ERROR; 2026-07-29-17:03:58; .../cake-autorate.sh: ((:
ERROR; 2026-07-29-17:03:58; dl_owd_us=10#: invalid integer constant (error token is "10#")

Jul 29 17:03:58 chronyd[1273]: System clock was stepped by -1.759986 seconds
```

The clock stepped backwards while a ping was in flight, so fping reported a negative RTT. It prints such a value rather than dropping it — `sprint_tm()` has a branch labelled `/* negative (unexpected) */` that formats it with `%.2g`. The line still has 12 fields, so it passed the response gate, and then the parse hit this:

```console
$ rtt_ms="-1.8e+03"; printf -v rtt_us %.3f "${rtt_ms}"; (( dl_owd_us=10#${rtt_us//.}/2 ))
bash: ((: dl_owd_us=10#: invalid integer constant (error token is "10#")
```

Base notation can't carry a sign, bash aborts the whole arithmetic compound, and the cleanup trap takes the daemon down with exit 0.

The fix rejects an RTT token containing anything outside `[0-9.]`, at the response gate. It's a glob class check rather than a regex on purpose: `[[ =~ ]]` recompiles the ERE on every sample, which measured ~32 µs against ~0.5 µs for the pattern match. A line that doesn't match simply isn't treated as a reflector response, so there's no new control flow, and a nonsense sample no longer reaches the OWD baselines.

Only the fping arm needs this. As @rany2 pointed out, iputils clamps a backward step to zero instead of reporting it, so `ping` can't produce a value that breaks the arithmetic. irtt, tsping and fping-ts are unaffected too — their parsers subtract integer timestamps, where a negative intermediate value is legal.

Checked with `bash -n`, and `shellcheck -x` reports the same two pre-existing findings as master and nothing new. I fed the gate normal fping lines, negative-RTT lines, `ICMP Host Unreachable` and `timed out` lines, and it accepts and rejects the right ones. It's been running on my own router since the incident.

For the record: the router is NixOS, not Debian as this description originally said — it was Debian until mid-July, and I carried the old wording over by mistake.