### PR TITLE
Use irtt streaming mode (-s) for unbounded pinger sessions

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -514,60 +514,40 @@ start_pinger()
 		irtt)
 			sleep_until_next_pinger_time_slot "${pinger}"
 
+			# The raw stream (-r) carries neither the reflector nor a wall-clock
+			# timestamp, and every pinger shares the one response fd, so a
+			# plain-bash helper prefixes both onto each line; the parsing itself
+			# lives with the other pinger methods in the main loop. A server-side
+			# max duration clamps the negotiated session and the client just
+			# exits, so the helper also respawns the client, rate-limited when
+			# the stream dies quickly (unreachable reflector, refused dial).
+			# --loose accepts server-restricted test parameters (e.g. a public
+			# server's min send interval): without it the client exits pre-test
+			# on any restriction and the respawn loop would spin forever
+			# producing zero samples.
+			local irtt_target=${reflectors[$pinger]}
+			[[ ${irtt_target} == *:* ]] && irtt_target="[${irtt_target}]"
+
 			# shellcheck disable=SC2155  # the subshell status (echo $!) is intentionally unused
 			local pinger_pid=$( (
 				set -m
-				${ping_prefix_string} gawk -v extra_args="${ping_extra_args}" -v interval_s="${reflector_ping_interval_s}" -v duration_m="${irtt_session_duration_m}" -v reflector="${reflectors[$pinger]}" -f <(cat <<-'EOT'
-				@load "time"
-
-				function to_us(val, mult)
 				{
-					# Test bare /s$/ LAST: "5µs" and "5ns" also end in "s", so an
-					# earlier /s$/ branch would swallow them (mult=1000000) and the
-					# µs/ns branches would be unreachable -> sub-ms OWDs inflated 10^6x.
-					mult = (val ~ /ms$/) ? 1000    : \
-						   (val ~ /µs$/) ? 1       : \
-						   (val ~ /ns$/) ? 0.001   : \
-						   (val ~ /s$/)  ? 1000000 : -1
+					while :
+					do
+						session_start_s=${SECONDS}
 
-					if (val ~ /^-/ || mult < 0) return -1
-					return sprintf("%.0f", val * mult)
-				}
+						${ping_prefix_string} irtt client -s -r --loose ${ping_extra_args} -i "${reflector_ping_interval_s}s" "${irtt_target}" |
+							while read -r irtt_line
+							do
+								printf '%s %s %s\n' "${EPOCHREALTIME/.}" "${reflectors[$pinger]}" "${irtt_line}"
+							done
 
-				BEGIN {
-					FS = "[= ]+"
-
-					irtt_cmd = sprintf("stdbuf -oL irtt client %s -i '%ss' -d '%sm' '%s'", extra_args, interval_s, duration_m, (reflector ~ /:/ ? "[" reflector "]" : reflector))
-
-					while (1)
-					{
-						start_time = systime()
-
-						while ((irtt_cmd | getline) > 0)
-						{
-							if (/seq=/ && /rd=/ && /sd=/)
-							{
-								ts = gensub(/\./, "", 1, sprintf("%.6f", gettimeofday()))
-								seq = $2; dl_owd = to_us($6); ul_owd = to_us($8)
-
-								if (dl_owd >= 0 && ul_owd >= 0)
-								{
-									printf("%s %s %d %d %d\n", ts, reflector, seq, dl_owd, ul_owd)
-									fflush("")
-								}
-							}
-							else if (/WaitForPackets/)
-							{
-								break
-							}
-						}
-
-						close(irtt_cmd)
-						if (systime() - start_time < 3) system("sleep 1")
-					}
-				}
-				EOT
-				) 2> /dev/null >&"${main_fd}" &
+						if (( SECONDS - session_start_s < 3 ))
+						then
+							sleep 1
+						fi
+					done
+				} 2> /dev/null >&"${main_fd}" &
 				echo $!
 			) )
 
@@ -1064,14 +1044,12 @@ then
 	log_msg "DEBUG" "Local list of reflectors now contains ${#reflectors[*]} entries."
 fi
 
-# Validate every reflector before use. For pinger_method=irtt a reflector is
-# interpolated into a shell command (gawk builds "irtt client ... '<reflector>'"
-# and runs it via | getline), so a reflector containing shell metacharacters is
-# command injection -- and reflectors can come unvalidated from the remote
-# reflectors_url (fetched over the network above, possibly without TLS) or from
-# a hand-edited config. Allow only IP-/hostname-shaped strings (no quotes, ';',
-# spaces, '$', etc.); the first char excludes '-' (blocks option injection) but
-# admits ':' for compressed IPv6 (e.g. ::1, ::ffff:1.2.3.4).
+# Validate every reflector before use. Reflectors can come unvalidated from the
+# remote reflectors_url (fetched over the network above, possibly without TLS)
+# or from a hand-edited config, and every pinger method hands them to its ping
+# binary as command-line arguments. Allow only IP-/hostname-shaped strings (no
+# quotes, ';', spaces, '$', etc.); the first char excludes '-' (blocks option
+# injection) but admits ':' for compressed IPv6 (e.g. ::1, ::ffff:1.2.3.4).
 for reflector in "${reflectors[@]}"
 do
 	[[ ${reflector} =~ ^[0-9A-Za-z:][0-9A-Za-z.:_-]*$ ]] || { log_msg "ERROR" "Invalid reflector '${reflector}': must be an IP address or hostname. Exiting script."; exit 1; }
@@ -1086,15 +1064,18 @@ case ${pinger_method} in
 		command -v "fping" &> /dev/null || { log_msg "ERROR" "ping binary fping does not exist. Exiting script."; exit 1; }
 		;;
 	irtt)
-		# The irtt path hard-requires gawk (gawk -f), the gawk-only 'time'
-		# extension (systime/gettimeofday) and stdbuf -- none of which are the
-		# 'irtt' binary. Without them the gawk pinger dies, but its stderr is
-		# /dev/null so the daemon is NOT killed: it silently produces no data and
-		# pins CAKE at the min rates. Name the missing dependency up front.
-		command -v "irtt"   &> /dev/null || { log_msg "ERROR" "ping binary irtt does not exist. Exiting script."; exit 1; }
-		command -v "gawk"   &> /dev/null || { log_msg "ERROR" "pinger_method=irtt requires gawk. Exiting script."; exit 1; }
-		command -v "stdbuf" &> /dev/null || { log_msg "ERROR" "pinger_method=irtt requires stdbuf (coreutils). Exiting script."; exit 1; }
-		gawk '@load "time"; BEGIN{exit}' < /dev/null &> /dev/null || { log_msg "ERROR" "pinger_method=irtt requires the gawk 'time' extension (gawk-gawkextra). Exiting script."; exit 1; }
+		# An irtt too old for streaming mode (< 0.9.2) rejects -s at every
+		# respawn, but the helper's stderr is /dev/null so the daemon is NOT
+		# killed: it silently produces no data and pins CAKE at the min rates.
+		# Probe the client help text for the capability up front instead. The
+		# help goes to stderr and 'irtt client -h' exits 2, so no pipe to grep
+		# (pipefail would poison the status even on a match); read -t bounds
+		# the probe so a non-conforming irtt that never exits on -h fails the
+		# check instead of hanging startup with no ERROR ever logged.
+		command -v "irtt" &> /dev/null || { log_msg "ERROR" "ping binary irtt does not exist. Exiting script."; exit 1; }
+		irtt_help=""
+		read -r -t 5 -d '' irtt_help < <(irtt client -h 2>&1)
+		[[ ${irtt_help} == *"streaming mode"* ]] || { log_msg "ERROR" "pinger_method=irtt requires irtt >= 0.9.2 (streaming mode). Exiting script."; exit 1; }
 		;;
 	*)
 		command -v "${pinger_method}" &> /dev/null || { log_msg "ERROR" "ping binary ${pinger_method} does not exist. Exiting script."; exit 1; }
@@ -1452,9 +1433,17 @@ do
 			case "${pinger_method}" in
 
 				irtt)
-					if ((${#command[@]} == 5))
+					# helper-prefixed raw stream line:
+					# ts reflector seqno rtt rd sd ipdv dup late
+					# rd/sd are the DL/UL OWDs in fixed-unit ms; ipdv is NaN on
+					# the first reply of a session, so it never gates a sample.
+					# The glob checks (patterns, not regexes: [[ =~ ]] recompiles
+					# the ERE every sample) drop NaN OWDs (no server timestamps),
+					# negative OWDs (client and server clocks out of step) and
+					# duplicates (dup=1 lines carry NaN OWDs by construction).
+					if ((${#command[@]} == 9)) && [[ ${command[4]} != *[!0-9.]* && ${command[5]} != *[!0-9.]* ]]
 					then
-						timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl_owd_us=${command[3]} ul_owd_us=${command[4]} reflector_response=1
+						timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl_owd_ms=${command[4]} ul_owd_ms=${command[5]} reflector_response=1
 					fi
 					;;
 				tsping)
@@ -1520,7 +1509,13 @@ do
 				case ${pinger_method} in
 
 					irtt)
+						printf -v dl_owd_us %.3f "${dl_owd_ms}"
+						printf -v ul_owd_us %.3f "${ul_owd_ms}"
+
 						((
+							dl_owd_us=10#${dl_owd_us//.},
+							ul_owd_us=10#${ul_owd_us//.},
+
 							dl_alpha = dl_owd_us >= dl_owd_baselines_us[${reflector}] ? alpha_baseline_increase : alpha_baseline_decrease,
 							ul_alpha = ul_owd_us >= ul_owd_baselines_us[${reflector}] ? alpha_baseline_increase : alpha_baseline_decrease,
 

--- a/defaults.sh
+++ b/defaults.sh
@@ -169,10 +169,10 @@ ping_extra_args=""
 # WARNING: no error checking - so use at own risk!
 ping_prefix_string=""
 
-# duration in minutes for each irtt session
-# irtt stores all results in-memory during a session
-# longer durations increase memory usage
-# lower values reduce memory but can cause gaps in data during session restarts
+# DEPRECATED and ignored: irtt sessions are now unbounded (streaming mode -s),
+# so there is no per-session in-memory result set left to cap and no periodic
+# session restart. The key is retained so existing config files that set it
+# remain valid.
 irtt_session_duration_m=10 # (minutes)
 
 # interval in ms for monitoring achieved rx/tx rates


### PR DESCRIPTION
Closes #394 — and, per the review discussion, gawk is now gone entirely: one `irtt client -s -r --loose -i <interval>` per reflector, parsed in the main loop like every other pinger method.

The raw stream carries neither the reflector nor a wall-clock timestamp, all pingers share the one response fd, and `irtt client` takes exactly one host per session (irtt_client.go:284) with no flag to tag its output — so a per-reflector plain-bash helper prefixes those two fields onto each line and handles the respawn (a server-side max duration clamps the negotiated session and the client just exits; rate-limited to one relaunch per second on quick deaths).

Per-line gating, now in the extraction arm: numeric `rd`/`sd` via glob class checks (no `[[ =~ ]]` on the hot path). That one check drops NaN OWDs (no server timestamps), duplicates (dup=1 lines carry NaN OWDs by construction) and negative OWDs (client and server clocks out of step — which `to_us()` used to reject, and the interim transcoder let through). `ipdv` is legitimately NaN on the first reply of every session and on seqno wrap (heistp confirmed the wrap behavior in heistp/irtt#45), so it never gates a sample. ms→µs uses the same `printf %.3f` idiom as the fping arm.

`--loose`: without it, any server-imposed restriction (e.g. a public server's min send interval) kills the client pre-test at every respawn — `[ServerRestriction] server increased interval from 100ms to 1s`, exit 1, zero samples, silent spin. Reproduced both ways against `irtt server -i 1s`.

Removed: the gawk + time-extension dependencies, the `-d` session bound, the `WaitForPackets` match, the unit-suffix parsing, and `stdbuf` (raw lines come from Go's unbuffered stdout — the old `stdbuf -oL` never had an effect for the same reason). In raw mode irtt routes events/notices to stderr, so stdout carries only sample lines. `ping_prefix_string` now wraps the irtt client itself, as in the other arms (it used to wrap gawk; the popen'd irtt never carried the prefix).

Validation: the gawk checks are gone; a time-bounded probe of `irtt client -h` checks for streaming-mode support — `-s` only exists since irtt 0.9.2, and without the probe an older irtt would reject `-s` at every respawn while the daemon silently produces no samples (min-rate pinning). No pipe to grep (the help goes to stderr and exits 2, which pipefail would turn into a false failure); `read -t` bounds it so a never-exiting irtt can't hang startup.

`irtt_session_duration_m`: deprecated-and-ignored rather than dropped, since dropping the key would break existing config files that set it — happy to drop outright instead, your call from the issue.

Also worth noting from heistp/irtt#45: a 1-hour 1 ms-interval stream (3.6M round trips) shows no leak, RSS stable ~12.5 MB.

Tested on a loopback rig (real irtt 0.9.2 server, wrapper and parser blocks extracted verbatim from the file): 9-field lines end-to-end, µs values matching irtt's own rd/sd within rounding, first sample kept, dup/NaN/negative/short/long lines dropped, respawn paced ~1/s across server restarts, group kill leaves no orphans, stdout stays pure across a server bounce, capability gate passes on 0.9.2 / fails on older / fails-not-hangs on a stuck binary; shellcheck finding count identical to master. Hot-path cost measured over 1M iterations: extraction arm 5.8→20.8 µs/sample (the ms→µs conversion moved in — same class of work the fping arm already does), helper 9.6 µs/line in its own background process vs 4.2 for the gawk stage; at `-i 0.3s` × 6 pingers that is under 0.1% of a core either way. Net diff vs master: −5 lines.