### PR TITLE
Reject nine-token ICMP error lines in the ping parser

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1484,13 +1484,6 @@ do
 					fi
 					;;
 				ping)
-					# Nine tokens alone do not prove a reply: with a PTR-resolving
-					# hop, an ICMP error line ("[ts] From host (ip) icmp_seq=1 Time
-					# to live exceeded") is also nine tokens and would parse as a
-					# 0 us sample keyed under a phantom "icmp_seq=1" reflector.
-					# Genuine replies always carry a time= token in field 7,
-					# no error shape does (glob check, same cost rationale as
-					# the fping guard above).
 					if ((${#command[@]} == 9)) && [[ ${command[7]} == time=* ]]
 					then
 						timestamp=${command[0]} reflector=${command[4]} seq=${command[5]} rtt_ms=${command[7]} reflector_response=1

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1484,7 +1484,14 @@ do
 					fi
 					;;
 				ping)
-					if ((${#command[@]} == 9))
+					# Nine tokens alone do not prove a reply: with a PTR-resolving
+					# hop, an ICMP error line ("[ts] From host (ip) icmp_seq=1 Time
+					# to live exceeded") is also nine tokens and would parse as a
+					# 0 us sample keyed under a phantom "icmp_seq=1" reflector.
+					# Genuine replies always carry a time= token in field 7,
+					# no error shape does (glob check, same cost rationale as
+					# the fping guard above).
+					if ((${#command[@]} == 9)) && [[ ${command[7]} == time=* ]]
 					then
 						timestamp=${command[0]} reflector=${command[4]} seq=${command[5]} rtt_ms=${command[7]} reflector_response=1
 					fi

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -593,7 +593,7 @@ start_pinger()
 			;;
 		ping)
 			sleep_until_next_pinger_time_slot "${pinger}"
-			${ping_prefix_string} ping ${ping_extra_args} -D -i "${reflector_ping_interval_s}" "${reflectors[pinger]}" 2> /dev/null >&"${main_fd}" &
+			${ping_prefix_string} ping ${ping_extra_args} -D -n -i "${reflector_ping_interval_s}" "${reflectors[pinger]}" 2> /dev/null >&"${main_fd}" &
 			pinger_pids[pinger]=${!}
 			proc_pids["ping_${pinger}_pinger"]=${pinger_pids[pinger]}
 			;;


### PR DESCRIPTION
The ping parser accepts any nine-token line. An ICMP error line from a hop with a PTR record is also nine tokens:

    [1754514000.123456] From one.one.one.one (1.1.1.1) icmp_seq=1 Time to live exceeded

and parses with `reflector="icmp_seq=1"` and `rtt_ms="live"`, i.e. a 0 us sample under a phantom reflector key. Real replies always carry `time=` in field 7 and no error shape does; this adds that gate as a glob test (same cost reasoning as the fping guard).

**Correction after rany2's review:** the first version of this text claimed fc9acaf removed such a check. That was wrong — the ping arm never had one, nothing was removed; this PR adds the missing validation.

The second commit adds `-n` to the ping invocation (rany2's suggestion): no reverse DNS in the datapath, which also removes this error-line shape at the source; the `time=` gate stays as the semantic check.

Checked the four iputils `-D` output shapes: v4/v6 replies accepted, error lines (with and without PTR) rejected. shellcheck unchanged.

Found while auditing our vendored copy; fping deployments are unaffected.
