### PR TITLE
README: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ sensors are created but never receive data.
 
 ## :stars: Stargazers <a name="stargazers"></a>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=lynxthecat/cake-autorate&type=Date)](https://star-history.com/#lynxthecat/cake-autorate&Date)
+[![Star History Chart](https://api.star-history.dera.page/svg?repos=lynxthecat/cake-autorate&type=Date)](https://star-history.dera.page/#lynxthecat/cake-autorate&Date)


### PR DESCRIPTION
The star history chart in the Stargazers section is currently broken: the service it relied on can no longer fetch stargazer data, so the chart fails to render. This updates the README to use a working replacement that serves the chart from the same domain, restoring the section without the need for an API token. Please consider merging so the project keeps its Stargazers chart in good shape.