### PR TITLE
Keep shaper state consistent with tc success

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -750,38 +750,64 @@ set_shaper_rate()
 {
 	# Fire up tc and update max_wire_packet_compensation if there are rates to change for the given direction
 
-	local direction=${1} # 'dl' or 'ul'
+	local direction=${1} tc_status=0 # 'dl' or 'ul'
 
-	(( shaper_rate_kbps[${direction}] != last_shaper_rate_kbps[${direction}] )) || return
+	(( shaper_rate_kbps[${direction}] != last_shaper_rate_kbps[${direction}] )) || return 0
 
 	((output_cake_changes)) && log_msg "SHAPER" "tc qdisc change root dev ${interface[${direction}]} cake bandwidth ${shaper_rate_kbps[${direction}]}Kbit"
 
 	if ((adjust_shaper_rate[${direction}]))
 	then
-		tc qdisc change root dev "${interface[${direction}]}" cake bandwidth "${shaper_rate_kbps[${direction}]}Kbit" 2> /dev/null
+		tc qdisc change root dev "${interface[${direction}]}" cake bandwidth "${shaper_rate_kbps[${direction}]}Kbit" 2> /dev/null || tc_status=${?}
+		((tc_status)) && log_msg "ERROR" "tc failed with status ${tc_status} while setting ${direction} shaper on ${interface[${direction}]} to ${shaper_rate_kbps[${direction}]}Kbit."
 	else
 		((output_cake_changes)) && log_msg "DEBUG" "adjust_${direction}_shaper_rate set to 0 in config, so skipping the corresponding tc qdisc change call."
 	fi
 
-	# Compensate for delays imposed by active traffic shaper
-	# This will serve to increase the delay thr at rates below around 12Mbit/s
-	((
-		dl_compensation_us=(1000*dl_max_wire_packet_size_bits)/shaper_rate_kbps[dl],
-		ul_compensation_us=(1000*ul_max_wire_packet_size_bits)/shaper_rate_kbps[ul],
-
-		compensated_avg_owd_delta_max_adjust_up_thr_us[dl]=dl_avg_owd_delta_max_adjust_up_thr_us + dl_compensation_us,
-		compensated_avg_owd_delta_max_adjust_up_thr_us[ul]=ul_avg_owd_delta_max_adjust_up_thr_us + ul_compensation_us,
-
-		compensated_owd_delta_delay_thr_us[dl]=dl_owd_delta_delay_thr_us + dl_compensation_us,
-		compensated_owd_delta_delay_thr_us[ul]=ul_owd_delta_delay_thr_us + ul_compensation_us,
-
-		compensated_avg_owd_delta_max_adjust_down_thr_us[dl]=dl_avg_owd_delta_max_adjust_down_thr_us + dl_compensation_us,
-		compensated_avg_owd_delta_max_adjust_down_thr_us[ul]=ul_avg_owd_delta_max_adjust_down_thr_us + ul_compensation_us,
-
-		max_wire_packet_rtt_us=(1000*dl_max_wire_packet_size_bits)/shaper_rate_kbps[dl] + (1000*ul_max_wire_packet_size_bits)/shaper_rate_kbps[ul],
-
+	if ((tc_status == 0))
+	then
 		last_shaper_rate_kbps[${direction}]=${shaper_rate_kbps[${direction}]}
-	))
+
+		# Compensate only for rates known to be installed. On a failed tc
+		# change, retaining the previous compensation keeps the control loop
+		# consistent with the qdisc and leaves this rate pending for retry.
+		if ((last_shaper_rate_kbps[dl] && last_shaper_rate_kbps[ul]))
+		then
+			((
+				dl_compensation_us=(1000*dl_max_wire_packet_size_bits)/last_shaper_rate_kbps[dl],
+				ul_compensation_us=(1000*ul_max_wire_packet_size_bits)/last_shaper_rate_kbps[ul],
+
+				compensated_avg_owd_delta_max_adjust_up_thr_us[dl]=dl_avg_owd_delta_max_adjust_up_thr_us + dl_compensation_us,
+				compensated_avg_owd_delta_max_adjust_up_thr_us[ul]=ul_avg_owd_delta_max_adjust_up_thr_us + ul_compensation_us,
+
+				compensated_owd_delta_delay_thr_us[dl]=dl_owd_delta_delay_thr_us + dl_compensation_us,
+				compensated_owd_delta_delay_thr_us[ul]=ul_owd_delta_delay_thr_us + ul_compensation_us,
+
+				compensated_avg_owd_delta_max_adjust_down_thr_us[dl]=dl_avg_owd_delta_max_adjust_down_thr_us + dl_compensation_us,
+				compensated_avg_owd_delta_max_adjust_down_thr_us[ul]=ul_avg_owd_delta_max_adjust_down_thr_us + ul_compensation_us,
+
+				max_wire_packet_rtt_us=(1000*dl_max_wire_packet_size_bits)/last_shaper_rate_kbps[dl] + (1000*ul_max_wire_packet_size_bits)/last_shaper_rate_kbps[ul]
+			))
+		fi
+	fi
+	return "${tc_status}"
+}
+
+initialize_shaper_rates()
+{
+	local dl_tc_status ul_tc_status
+
+	set_shaper_rate "dl"
+	dl_tc_status=${?}
+	set_shaper_rate "ul"
+	ul_tc_status=${?}
+
+	if ((dl_tc_status || ul_tc_status))
+	then
+		log_msg "ERROR" "Initial CAKE shaper rate configuration failed. Exiting script."
+		return 1
+	fi
+	return 0
 }
 
 set_min_shaper_rates()
@@ -1323,8 +1349,9 @@ avg_owd_delta_us[dl]=0 avg_owd_delta_us[ul]=0
 avg_owd_delta_max_adjust_up_thr_us[dl]=${dl_avg_owd_delta_max_adjust_up_thr_us} avg_owd_delta_max_adjust_up_thr_us[ul]=${ul_avg_owd_delta_max_adjust_up_thr_us} \
 avg_owd_delta_max_adjust_down_thr_us[dl]=${dl_avg_owd_delta_max_adjust_down_thr_us} avg_owd_delta_max_adjust_down_thr_us[ul]=${ul_avg_owd_delta_max_adjust_down_thr_us}
 
-set_shaper_rate "dl"
-set_shaper_rate "ul"
+initialize_shaper_rates
+initial_shaper_rate_status=${?}
+((initial_shaper_rate_status)) && exit 1
 
 dl_rate_load_condition="idle" ul_rate_load_condition="idle"
 

--- a/tests/test_set_shaper_rate.sh
+++ b/tests/test_set_shaper_rate.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+script_path="${repo_root}/cake-autorate.sh"
+
+extract_function() {
+	local function_name=${1}
+
+	awk '
+		$0 == function_name "()" { capture=1 }
+		capture { print }
+		capture && /^}$/ { exit }
+	' function_name="${function_name}" "${script_path}"
+}
+
+assert_eq() {
+	local expected=${1} actual=${2} message=${3}
+	[[ ${actual} == "${expected}" ]] || {
+		printf 'assert_eq failed: %s\nexpected: %s\nactual:   %s\n' "${message}" "${expected}" "${actual}" >&2
+		exit 1
+	}
+}
+
+assert_tc_calls() {
+	local expected=${1} message=${2}
+	assert_eq "${expected}" "${#tc_calls[@]}" "${message}"
+}
+
+# shellcheck disable=SC2034  # globals are consumed by extracted functions via eval
+setup_common_state() {
+	declare -gA shaper_rate_kbps=([dl]=20000 [ul]=5000)
+	declare -gA last_shaper_rate_kbps=([dl]=25000 [ul]=5000)
+	declare -gA interface=([dl]=ifb-wan0 [ul]=wan0)
+	declare -gA adjust_shaper_rate=([dl]=1 [ul]=1)
+
+	declare -gA compensated_avg_owd_delta_max_adjust_up_thr_us=([dl]=0 [ul]=0)
+	declare -gA compensated_owd_delta_delay_thr_us=([dl]=0 [ul]=0)
+	declare -gA compensated_avg_owd_delta_max_adjust_down_thr_us=([dl]=0 [ul]=0)
+
+	declare -g output_cake_changes=0
+	declare -g dl_max_wire_packet_size_bits=12000
+	declare -g ul_max_wire_packet_size_bits=6000
+	declare -g dl_avg_owd_delta_max_adjust_up_thr_us=100
+	declare -g ul_avg_owd_delta_max_adjust_up_thr_us=200
+	declare -g dl_owd_delta_delay_thr_us=300
+	declare -g ul_owd_delta_delay_thr_us=400
+	declare -g dl_avg_owd_delta_max_adjust_down_thr_us=500
+	declare -g ul_avg_owd_delta_max_adjust_down_thr_us=600
+	declare -g dl_compensation_us=11
+	declare -g ul_compensation_us=22
+	declare -g max_wire_packet_rtt_us=333
+
+	declare -ga tc_calls=()
+	declare -ga log_messages=()
+	declare -gA tc_status_by_interface=([ifb-wan0]=0 [wan0]=0)
+
+	log_msg() {
+		log_messages+=("$*")
+	}
+
+	tc() {
+		tc_calls+=("$*")
+		return "${tc_status_by_interface[${5}]}"
+	}
+
+	eval "$(extract_function set_shaper_rate)"
+	eval "$(extract_function initialize_shaper_rates)"
+}
+
+test_success_updates_state_after_tc() {
+	setup_common_state
+
+	set_shaper_rate dl
+	local status=$?
+
+	assert_eq "0" "${status}" "successful tc call should return 0"
+	assert_tc_calls "1" "successful tc change should call tc once"
+	assert_eq "20000" "${last_shaper_rate_kbps[dl]}" "successful tc should commit the new dl rate"
+	assert_eq "600" "${dl_compensation_us}" "successful tc should recompute dl compensation"
+	assert_eq "1200" "${ul_compensation_us}" "successful tc should recompute ul compensation"
+	assert_eq "1800" "${max_wire_packet_rtt_us}" "successful tc should recompute max wire packet RTT"
+}
+
+test_failure_preserves_previous_state() {
+	setup_common_state
+	tc_status_by_interface[ifb-wan0]=42
+
+	set +e
+	set_shaper_rate dl
+	local status=$?
+	set -e
+
+	assert_eq "42" "${status}" "failed tc call should propagate its status"
+	assert_tc_calls "1" "failed tc change should still call tc once"
+	assert_eq "25000" "${last_shaper_rate_kbps[dl]}" "failed tc must not advance the committed dl rate"
+	assert_eq "11" "${dl_compensation_us}" "failed tc must preserve previous dl compensation"
+	assert_eq "22" "${ul_compensation_us}" "failed tc must preserve previous ul compensation"
+	assert_eq "333" "${max_wire_packet_rtt_us}" "failed tc must preserve previous RTT compensation"
+	assert_eq "ERROR tc failed with status 42 while setting dl shaper on ifb-wan0 to 20000Kbit." "${log_messages[-1]}" "failed tc should emit an error log"
+}
+
+test_retry_repeats_tc_until_success() {
+	setup_common_state
+	tc_status_by_interface[ifb-wan0]=42
+	set +e
+	set_shaper_rate dl
+	set -e
+
+	tc_status_by_interface[ifb-wan0]=0
+	set_shaper_rate dl
+	local status=$?
+
+	assert_eq "0" "${status}" "retry after a failure should succeed when tc succeeds"
+	assert_tc_calls "2" "failed shaper change must remain pending for retry"
+	assert_eq "20000" "${last_shaper_rate_kbps[dl]}" "successful retry should finally commit the new dl rate"
+}
+
+# shellcheck disable=SC2034  # the extracted function consumes this assignment via eval
+test_cross_direction_failure_uses_committed_rates() {
+	setup_common_state
+	shaper_rate_kbps[ul]=4000
+	tc_status_by_interface[ifb-wan0]=42
+
+	set +e
+	set_shaper_rate dl
+	local dl_status=$?
+	set -e
+	set_shaper_rate ul
+	local ul_status=$?
+
+	assert_eq "42" "${dl_status}" "failed dl tc call should propagate its status"
+	assert_eq "0" "${ul_status}" "successful ul tc call should return 0"
+	assert_tc_calls "2" "each pending direction should call tc once"
+	assert_eq "25000" "${last_shaper_rate_kbps[dl]}" "failed dl tc must preserve its committed rate"
+	assert_eq "4000" "${last_shaper_rate_kbps[ul]}" "successful ul tc must commit its new rate"
+	assert_eq "480" "${dl_compensation_us}" "ul success must use the committed dl rate"
+	assert_eq "1500" "${ul_compensation_us}" "ul success must use the committed ul rate"
+	assert_eq "1980" "${max_wire_packet_rtt_us}" "RTT compensation must use both committed rates"
+}
+
+test_startup_failure_propagates_without_initializing_rtt() {
+	setup_common_state
+	last_shaper_rate_kbps[dl]=0
+	last_shaper_rate_kbps[ul]=0
+	unset max_wire_packet_rtt_us
+	tc_status_by_interface[ifb-wan0]=42
+	tc_status_by_interface[wan0]=43
+
+	set +e
+	initialize_shaper_rates
+	local status=$?
+	set -e
+
+	assert_eq "1" "${status}" "startup must fail when either initial tc call fails"
+	assert_tc_calls "2" "startup should attempt both initial qdisc changes"
+	assert_eq "0" "${last_shaper_rate_kbps[dl]}" "failed startup must not commit dl"
+	assert_eq "0" "${last_shaper_rate_kbps[ul]}" "failed startup must not commit ul"
+	[[ ! -v max_wire_packet_rtt_us ]] || {
+		printf 'startup failure unexpectedly initialized max_wire_packet_rtt_us\n' >&2
+		return 1
+	}
+	assert_eq "ERROR Initial CAKE shaper rate configuration failed. Exiting script." "${log_messages[-1]}" "startup failure should be logged before exit"
+}
+
+test_success_updates_state_after_tc
+test_failure_preserves_previous_state
+test_retry_repeats_tc_until_success
+test_cross_direction_failure_uses_committed_rates
+test_startup_failure_propagates_without_initializing_rtt
+
+printf 'ok\n'


### PR DESCRIPTION
## Summary

- commit an internal shaper rate only after the corresponding `tc qdisc change` succeeds
- derive packet-delay compensation from rates known to be installed in both directions
- propagate `tc` failures, leave failed changes pending for retry, and fail initial setup before starting the monitor
- add focused fake-`tc` regressions for success, failure, retry, mixed-direction failure, and startup failure

## Root cause

`set_shaper_rate()` updated `last_shaper_rate_kbps` and all derived compensation values regardless of the exit status from `tc`. A failed qdisc change therefore made the controller believe the requested rate was active even though the kernel still used the previous rate.

The mismatch also crossed directions: after a failed download update, a successful upload update could recompute both compensations from the pending download value. During startup, failed qdisc configuration could similarly let monitoring begin without a coherent initialized state.

## Impact

The controller now keeps its state aligned with the qdisc, retries failed changes naturally, and exits safely if the initial shaper setup cannot be installed. The rate-selection algorithm is unchanged.

## Tests

- `bash -n cake-autorate.sh tests/test_set_shaper_rate.sh`
- `tests/test_set_shaper_rate.sh`
- ShellCheck on the new test; no new diagnostics versus upstream for the main script
- `git diff --check`

Prepared with assistance from OpenAI Codex.
