### PR TITLE
Preserve fatal exit status for service managers

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -24,7 +24,8 @@ required tools. To use it:
 
 - [SSH into the router](https://openwrt.org/docs/guide-quick-start/sshadministration)
 
-- Ensure `bash` and `fping` are installed.
+- Ensure Bash 5.1 or newer and `fping` are installed. The launcher relies on
+  Bash's `wait -n -p` support and the installer rejects older Bash versions.
 
   On most OpenWrt installations, you can install them by running:
 
@@ -40,6 +41,10 @@ required tools. To use it:
   apk update
   apk add bash fping
   ```
+
+  Verify the installed version with `bash --version`. If the package supplied
+  by an older OpenWrt release is below 5.1, that package does not satisfy this
+  requirement; use a supported release or otherwise provide a newer Bash.
 
 - Use the installer script by copying and pasting each of the commands
   below. The commands retrieve the current version from this repo:
@@ -58,8 +63,8 @@ required tools. To use it:
 
 - [SSH into the router](https://github.com/RMerl/asuswrt-merlin.ng/wiki/SSHD)
 
-- Make sure these are installed: entware; coreutils-mktemp; jsonfilter; bash;
-  and iputils-ping or fping.
+- Make sure these are installed: entware; coreutils-mktemp; jsonfilter; Bash
+  5.1 or newer; and iputils-ping or fping.
 
   - Firstly, if not already installed,
     [install entware](https://github.com/RMerl/asuswrt-merlin.ng/wiki/Entware);

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# No child processes need cleanup during prefix and function discovery.
+trap 'exit 0' INT TERM
+
 # cake-autorate automatically adjusts CAKE bandwidth(s)
 # in dependence on: a) receive and transmit transfer rates; and b) latency
 # (or can just be used to monitor and log transfer rates and latency)
@@ -94,18 +97,25 @@ fi
 # get valid config overrides
 mapfile -t valid_config_entries < <(grep -E '^[^(#| )].*=' "${SCRIPT_PREFIX}/defaults.sh" | sed -e 's/[\t ]*\#.*//g' -e 's/=.*//g')
 
-trap cleanup_and_killall INT TERM EXIT
-
 cleanup_and_killall()
 {	
+	local exit_status=${1:-0} config_path_for_log=${config_path:-unknown}
+
 	# Do not fail on error for this critical cleanup code
 	set +e
+	set +u
 
 	trap : INT TERM EXIT
+
+	if [[ -n ${run_path:-} && -f ${run_path}/fatal_error ]]
+	then
+		read -r exit_status < "${run_path}/fatal_error" 2>/dev/null || exit_status=1
+		[[ ${exit_status} =~ ^[0-9]+$ ]] || exit_status=1
+	fi
 	
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
 	
-	log_msg "INFO" "Stopping cake-autorate with PID: ${BASHPID} and config: ${config_path}"
+	log_msg "INFO" "Stopping cake-autorate with PID: ${BASHPID} and config: ${config_path_for_log}"
 	
 	log_msg "INFO" "Killing all background processes and cleaning up temporary files."
 
@@ -116,7 +126,7 @@ cleanup_and_killall()
 	((terminate_maintain_log_file_timeout_ms=log_file_buffer_timeout_ms+500))
 	terminate "${proc_pids['maintain_log_file']:-}" "${terminate_maintain_log_file_timeout_ms}"
 
-	[[ -d ${run_path} ]] && rm -r "${run_path}"
+	[[ -n ${run_path:-} && -d ${run_path} ]] && rm -r "${run_path}"
 	rmdir /var/run/cake-autorate 2>/dev/null
 
 	# give some time for processes to gracefully exit
@@ -149,10 +159,23 @@ cleanup_and_killall()
 		terminate "${intercept_stderr_pid}"
 	fi
 
-	log_msg "SYSLOG" "Stopped cake-autorate with PID: ${BASHPID} and config: ${config_path}"
+	log_msg "SYSLOG" "Stopped cake-autorate with PID: ${BASHPID} and config: ${config_path_for_log}"
 
 	trap - INT TERM EXIT
-	exit
+	exit "${exit_status}"
+}
+
+request_fatal_exit()
+{
+	local exit_status=${1:-1}
+
+	if [[ -n ${run_path:-} && -d ${run_path} ]]
+	then
+		printf '%s\n' "${exit_status}" > "${run_path}/fatal_error" 2>/dev/null || :
+	fi
+
+	kill -TERM "$$" 2>/dev/null || :
+	exit "${exit_status}"
 }
 
 log_msg()
@@ -599,7 +622,7 @@ start_pinger()
 			;;
 		*)
 			log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
-			kill $$ 2>/dev/null
+			exit 1
 			;;
 	esac
 
@@ -624,7 +647,7 @@ start_pingers()
 			;;
 		*)
 			log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
-			kill $$ 2>/dev/null
+			exit 1
 			;;
 	esac
 	pingers_active=1
@@ -681,7 +704,7 @@ stop_pingers()
 			;;
 		*)
 			log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
-			kill $$ 2>/dev/null
+			exit 1
 			;;
 	esac
 	pingers_active=0
@@ -844,7 +867,7 @@ change_state_main()
 		*)
 
 			log_msg "ERROR" "Received unrecognized main state change request: ${main_next_state}. Exiting now."
-			kill $$ 2>/dev/null
+			exit 1
 			;;
 	esac
 }
@@ -857,7 +880,7 @@ intercept_stderr()
 	while read -r error
 	do
 		log_msg "ERROR" "${error}"
-		kill $$ 2>/dev/null
+		request_fatal_exit 1
 	done
 }
 
@@ -906,6 +929,10 @@ validate_config_entry() {
 		printf '%s' "${valid_type}"
 	fi
 }
+
+trap 'cleanup_and_killall 0' INT
+trap 'cleanup_and_killall 0' TERM
+trap 'cleanup_and_killall "$?"' EXIT
 
 # ======= Start of the Main Routine ========
 
@@ -1491,7 +1518,7 @@ do
 					;;
 				*)
 					log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
-					kill $$ 2>/dev/null
+					exit 1
 				;;
 			esac
 			;;
@@ -1816,7 +1843,7 @@ do
 							;;
 						*)
 							log_msg "ERROR" "unknown load condition: ${load_condition[${direction}]}"
-							kill $$ 2>/dev/null
+							exit 1
 							;;
 					esac
 				done

--- a/launcher.sh.template
+++ b/launcher.sh.template
@@ -1,9 +1,100 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 
+trap 'exit 0' INT TERM
+exec {cleanup_sleep_fd}<> <(:)
+
+operator_stop_requested=0
+supervision_ready=0
+trap 'operator_stop_requested=1; ((supervision_ready)) && exit 0' INT TERM
+
 # An unmatched glob must expand to nothing (not the literal pattern), so a
 # missing config set yields an empty array instead of a bogus instance path.
 shopt -s nullglob
+
+declare -A active_cake_instance_pids=()
+declare -A cake_instance_pgids=()
+
+process_group_exists()
+{
+	local pgid=${1}
+
+	kill -0 -- "-${pgid}" 2>/dev/null
+}
+
+# Called by cleanup_and_exit, which is invoked indirectly by the EXIT trap.
+# shellcheck disable=SC2329
+prune_empty_instance_groups()
+{
+	local pgid
+
+	for pgid in "${!cake_instance_pgids[@]}"
+	do
+		process_group_exists "${pgid}" || unset "cake_instance_pgids[${pgid}]"
+	done
+}
+
+# Invoked indirectly by the EXIT trap.
+# shellcheck disable=SC2329
+cleanup_and_exit()
+{
+	local exit_status=${1:-1} cake_instance_pid pgid check
+
+	trap '' INT TERM
+	trap - EXIT
+
+	prune_empty_instance_groups
+	# Bash has no pidfd-like handle for a process group, so an empty PGID could in
+	# theory be reused between this probe and a signal. Signalling immediately and
+	# creating no polling subprocesses keeps that unavoidable window minimal.
+	for pgid in "${!cake_instance_pgids[@]}"
+	do
+		kill -TERM -- "-${pgid}" 2>/dev/null || true
+		kill -CONT -- "-${pgid}" 2>/dev/null || true
+	done
+
+	# Give every instance group up to three seconds to stop gracefully. A PGID
+	# cannot be reused while any member remains in that group.
+	for ((check=0; check<30 && ${#cake_instance_pgids[@]}; check++))
+	do
+		prune_empty_instance_groups
+		((${#cake_instance_pgids[@]})) && read -r -t 0.1 -u "${cleanup_sleep_fd}" || true
+	done
+
+	prune_empty_instance_groups
+	for pgid in "${!cake_instance_pgids[@]}"
+	do
+		kill -KILL -- "-${pgid}" 2>/dev/null || true
+	done
+
+	# Do not let a direct wait defeat the cleanup bound. Once its process group is
+	# empty, the direct child has terminated and wait only consumes saved status.
+	for ((check=0; check<10 && ${#cake_instance_pgids[@]}; check++))
+	do
+		prune_empty_instance_groups
+		((${#cake_instance_pgids[@]})) && read -r -t 0.1 -u "${cleanup_sleep_fd}" || true
+	done
+	for cake_instance_pid in "${!active_cake_instance_pids[@]}"
+	do
+		if ! process_group_exists "${cake_instance_pid}"
+		then
+			wait "${cake_instance_pid}" 2>/dev/null || true
+		fi
+		unset "active_cake_instance_pids[${cake_instance_pid}]"
+	done
+
+	exit "${exit_status}"
+}
+
+trap 'cleanup_and_exit "$?"' EXIT
+
+if ((BASH_VERSINFO[0] < 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1)))
+then
+	printf '%s\n' "cake-autorate: launcher requires bash >= 5.1" >&2
+	exit 1
+fi
+
+((operator_stop_requested)) && exit 0
 
 cake_instances=()
 if command -v uci >/dev/null 2>&1 && uci show cake-autorate >/dev/null 2>&1
@@ -26,32 +117,48 @@ else
 	cake_instances=(%%CONFIG_PREFIX%%/config.*.sh)
 fi
 
+((operator_stop_requested)) && exit 0
+
 if [[ ${#cake_instances[@]} -eq 0 ]]
 then
 	printf '%s\n' "cake-autorate: no config files found in %%CONFIG_PREFIX%%" >&2
 	exit 1
 fi
 
-cake_instance_pids=()
-
-trap kill_cake_instances INT TERM EXIT
-
-kill_cake_instances()
-{
-	trap - INT TERM EXIT
-
-	echo "Killing all instances of cake one-by-one now."
-
-	for ((cake_instance=0; cake_instance<${#cake_instances[@]}; cake_instance++))
-	do
-		kill "${cake_instance_pids[${cake_instance}]}" 2>/dev/null || true
-	done
-	wait
-}
-
+# In a non-interactive Bash, monitor mode gives each asynchronous simple command
+# a dedicated process group whose leader is $!. Ordinary descendants inherit it.
+set -m
 for cake_instance in "${cake_instances[@]}"
 do
-	%%SCRIPT_PREFIX%%/cake-autorate.sh "${cake_instance}" &
-	cake_instance_pids+=(${!})
+	%%SCRIPT_PREFIX%%/cake-autorate.sh "${cake_instance}" {cleanup_sleep_fd}>&- &
+	cake_instance_pid=${!}
+	active_cake_instance_pids[${cake_instance_pid}]=1
+	cake_instance_pgids[${cake_instance_pid}]=1
+	((operator_stop_requested)) && exit 0
 done
-wait
+
+# From this point every direct child is tracked, so signals may stop immediately.
+# shellcheck disable=SC2034  # Read indirectly by the INT/TERM trap.
+supervision_ready=1
+((operator_stop_requested)) && exit 0
+
+while ((${#active_cake_instance_pids[@]}))
+do
+	completed_pid=
+	wait -n -f -p completed_pid "${!active_cake_instance_pids[@]}"
+	child_status=${?}
+
+	# wait -n has already reaped this PID. Remove it before cleanup can signal
+	# another child. Keep its PGID only while workers still occupy the group.
+	if [[ ! ${completed_pid} =~ ^[0-9]+$ || ! ${active_cake_instance_pids[${completed_pid}]+present} ]]
+	then
+		printf '%s\n' "cake-autorate: launcher failed to identify a completed child" >&2
+		exit 1
+	fi
+	unset "active_cake_instance_pids[${completed_pid}]"
+	process_group_exists "${completed_pid}" || unset "cake_instance_pgids[${completed_pid}]"
+
+	((child_status == 0)) || exit "${child_status}"
+done
+
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -101,6 +101,11 @@ main() {
 			exit_now=1
 		fi
 	done
+	if type bash >/dev/null 2>&1 && ! bash -c '((BASH_VERSINFO[0] > 5 || (BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)))'
+	then
+		printf >&2 "bash 5.1 or newer is required, please upgrade it and rerun the script!\n"
+		exit_now=1
+	fi
 	dep_found=0
 	for dep in curl wget
 	do

--- a/tests/fatal-status.sh
+++ b/tests/fatal-status.sh
@@ -1,0 +1,554 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+set -u
+set -o pipefail
+
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+declare -A tracked_pids=()
+fixture_dir=
+suite_failed=0
+wait_status=0
+exec {test_sleep_fd}<> <(:)
+
+cleanup()
+{
+	local pid pid_file
+
+	trap - INT TERM EXIT
+	if ((suite_failed)); then
+		if [[ -d ${fixture_dir} ]]; then
+			for pid_file in "${fixture_dir}"/*.pids
+			do
+				[[ -f ${pid_file} ]] || continue
+				while read -r pid
+				do
+					[[ ${pid} =~ ^[0-9]+$ ]] && tracked_pids[${pid}]=1
+				done < <(tr ' ' '\n' < "${pid_file}")
+			done
+		fi
+		for pid in "${!tracked_pids[@]}"
+		do
+			kill -CONT "${pid}" 2>/dev/null || true
+			kill -TERM "${pid}" 2>/dev/null || true
+		done
+		read -r -t 0.05 -u "${test_sleep_fd}" || true
+		for pid in "${!tracked_pids[@]}"
+		do
+			kill -KILL "${pid}" 2>/dev/null || true
+			wait "${pid}" 2>/dev/null || true
+		done
+	fi
+	[[ -n ${fixture_dir} ]] && rm -r "${fixture_dir}" 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+fail()
+{
+	suite_failed=1
+	printf 'not ok - %s\n' "${1}" >&2
+	exit 1
+}
+
+ok()
+{
+	printf 'ok - %s\n' "${1}"
+}
+
+pause()
+{
+	read -r -t "${1}" -u "${test_sleep_fd}" || true
+}
+
+assert_eq()
+{
+	local expected=${1} actual=${2} context=${3}
+
+	[[ ${actual} == "${expected}" ]] || fail "${context}: expected '${expected}', got '${actual}'"
+}
+
+make_tmp_dir()
+{
+	[[ -z ${fixture_dir} ]] || rm -r "${fixture_dir}" 2>/dev/null || fail "failed to remove prior fixture"
+	fixture_dir=$(mktemp -d) || fail "failed to create temporary directory"
+}
+
+wait_for_file()
+{
+	local path=${1} attempt
+
+	for ((attempt=0; attempt<2000; attempt++))
+	do
+		[[ -f ${path} ]] && return 0
+		pause 0.01
+	done
+	return 1
+}
+
+wait_with_timeout()
+{
+	local pid=${1} context=${2} watchdog marker
+
+	marker=${3}/watchdog.${pid}
+	trap - EXIT
+	(
+		read -r -t 10 -u "${test_sleep_fd}" || true
+		: > "${marker}"
+		kill -TERM "${pid}" 2>/dev/null || exit 0
+		read -r -t 1 -u "${test_sleep_fd}" || true
+		kill -KILL "${pid}" 2>/dev/null || true
+	) &
+	watchdog=${!}
+	trap cleanup EXIT
+	wait "${pid}"
+	wait_status=${?}
+	unset "tracked_pids[${pid}]"
+	kill -TERM "${watchdog}" 2>/dev/null || true
+	wait "${watchdog}" 2>/dev/null || true
+	[[ ! -f ${marker} ]] || fail "${context}: timed out"
+}
+
+assert_pid_gone()
+{
+	local pid=${1} context=${2} attempt
+
+	for ((attempt=0; attempt<100; attempt++))
+	do
+		if ! kill -0 "${pid}" 2>/dev/null
+		then
+			unset "tracked_pids[${pid}]"
+			return
+		fi
+		pause 0.01
+	done
+	fail "${context}: PID ${pid} is still running"
+}
+
+read_direct_child_pids()
+{
+	local pid_file=${1} expected_parent=${2}
+
+	read -r child_pid child_parent_pid < "${pid_file}" || fail "missing PID record ${pid_file}"
+	[[ ${child_pid} =~ ^[0-9]+$ && ${child_parent_pid} =~ ^[0-9]+$ ]] || fail "invalid PID record ${pid_file}"
+	assert_eq "${expected_parent}" "${child_parent_pid}" "cake instance must be a direct launcher child"
+	tracked_pids[${child_pid}]=1
+}
+
+render_launcher()
+{
+	local script_prefix=${1} config_prefix=${2} launcher=${3}
+
+	sed -e "s|%%SCRIPT_PREFIX%%|${script_prefix}|g" \
+		-e "s|%%CONFIG_PREFIX%%|${config_prefix}|g" \
+		"${repo_dir}/launcher.sh.template" > "${launcher}" || fail "failed to render launcher"
+	chmod +x "${launcher}"
+}
+
+write_fake_cake()
+{
+	local path=${1}
+
+	cp "${repo_dir}/tests/fixtures/fake-cake.sh" "${path}" || fail "failed to copy fake cake fixture"
+	chmod +x "${path}"
+}
+
+make_launcher_fixture()
+{
+	make_tmp_dir
+	script_prefix=${fixture_dir}/script
+	config_prefix=${fixture_dir}/config
+	launcher=${fixture_dir}/launcher.sh
+	mkdir "${script_prefix}" "${config_prefix}"
+	render_launcher "${script_prefix}" "${config_prefix}" "${launcher}"
+	write_fake_cake "${script_prefix}/cake-autorate.sh"
+}
+
+start_launcher()
+{
+	local mode=${1} simultaneous=${2:-0} path_prefix=${3:-${PATH}} trace=${4:-0}
+	local -a bash_args=()
+
+	((trace)) && bash_args=(-x)
+
+	CAKE_AUTORATE_TEST_DIR=${fixture_dir} \
+	CAKE_AUTORATE_TEST_MODE=${mode} \
+	CAKE_AUTORATE_TEST_SIMULTANEOUS=${simultaneous} \
+	PATH=${path_prefix} \
+		bash "${bash_args[@]}" "${launcher}" {test_sleep_fd}>&- > "${fixture_dir}/launcher.out" 2>&1 &
+	launcher_pid=${!}
+	tracked_pids[${launcher_pid}]=1
+}
+
+write_blocking_uci()
+{
+	local path=${1}
+
+	cp "${repo_dir}/tests/fixtures/blocking-uci.sh" "${path}" || fail "failed to copy UCI fixture"
+	chmod +x "${path}"
+}
+
+test_term_during_config_discovery()
+{
+	local fake_bin
+
+	make_launcher_fixture
+	fake_bin=${fixture_dir}/bin
+	mkdir "${fake_bin}"
+	write_blocking_uci "${fake_bin}/uci"
+	start_launcher unexpected 0 "${fake_bin}:${PATH}"
+	wait_for_file "${fixture_dir}/discovery.ready" || fail "TERM discovery fixture did not become ready"
+	kill -TERM "${launcher_pid}"
+	: > "${fixture_dir}/discovery.release"
+	wait_with_timeout "${launcher_pid}" "TERM during config discovery" "${fixture_dir}"
+	assert_eq 0 "${wait_status}" "TERM during config discovery"
+	[[ ! -e ${fixture_dir}/cake.started ]] || fail "TERM during discovery started a cake instance"
+
+	ok "TERM trap is active during config discovery"
+}
+
+test_sigint_in_foreground_pty()
+{
+	local fake_bin status
+
+	make_launcher_fixture
+	fake_bin=${fixture_dir}/bin
+	mkdir "${fake_bin}"
+	write_blocking_uci "${fake_bin}/uci"
+	status=$(python3 "${repo_dir}/tests/fixtures/pty-runner.py" "${launcher}" "${fixture_dir}" "${fake_bin}:${PATH}") || fail "PTY SIGINT runner failed"
+	assert_eq 0 "${status}" "foreground Ctrl-C status"
+	[[ ! -e ${fixture_dir}/cake.started ]] || fail "foreground Ctrl-C started a cake instance"
+
+	ok "foreground PTY SIGINT returns zero during discovery"
+}
+
+test_child_failure_and_all_zero()
+{
+	local failed_pid slow_pid
+
+	make_launcher_fixture
+	: > "${config_prefix}/config.fail.sh"
+	: > "${config_prefix}/config.slow.sh"
+	start_launcher failure 0 "${PATH}" 1
+	wait_with_timeout "${launcher_pid}" "child status 42" "${fixture_dir}"
+	assert_eq 42 "${wait_status}" "launcher child failure status"
+	read_direct_child_pids "${fixture_dir}/fail.pids" "${launcher_pid}"
+	failed_pid=${child_pid}
+	read_direct_child_pids "${fixture_dir}/slow.pids" "${launcher_pid}"
+	slow_pid=${child_pid}
+	if grep -Eq "^\+* kill -TERM -- -${failed_pid}( |$)" "${fixture_dir}/launcher.out"
+	then
+		fail "launcher signalled the already-reaped failed PID"
+	fi
+	grep -Eq "^\+* kill -TERM -- -${slow_pid}( |$)" "${fixture_dir}/launcher.out" || fail "launcher did not signal the live sibling group"
+	assert_pid_gone "${failed_pid}" "failed child reap"
+	assert_pid_gone "${slow_pid}" "failed sibling cleanup"
+
+	make_launcher_fixture
+	: > "${config_prefix}/config.fast.sh"
+	: > "${config_prefix}/config.slow.sh"
+	start_launcher all-zero
+	wait_with_timeout "${launcher_pid}" "all-zero children" "${fixture_dir}"
+	assert_eq 0 "${wait_status}" "all children zero"
+	[[ -f ${fixture_dir}/fast.done && -f ${fixture_dir}/slow.done ]] || fail "launcher did not wait for every zero child"
+
+	ok "launcher propagates 42 and waits for all-zero children"
+}
+
+run_two_fail_race()
+{
+	local simultaneous=${1}
+
+	rm -f "${fixture_dir}"/{first,second}.{ready,pids,exiting} "${fixture_dir}/release"
+	start_launcher two-fail "${simultaneous}" "${PATH}" "${simultaneous}"
+	wait_for_file "${fixture_dir}/first.ready" || fail "first failing child did not become ready"
+	wait_for_file "${fixture_dir}/second.ready" || fail "second failing child did not become ready"
+	read_direct_child_pids "${fixture_dir}/first.pids" "${launcher_pid}"
+	first_pid=${child_pid}
+	read_direct_child_pids "${fixture_dir}/second.pids" "${launcher_pid}"
+	second_pid=${child_pid}
+	((simultaneous)) && kill -STOP "${launcher_pid}"
+	: > "${fixture_dir}/release"
+	if ((simultaneous))
+	then
+		wait_for_file "${fixture_dir}/first.exiting" || fail "first simultaneous child did not exit"
+		wait_for_file "${fixture_dir}/second.exiting" || fail "second simultaneous child did not exit"
+		pause 0.01
+		kill -CONT "${launcher_pid}"
+	fi
+	wait_with_timeout "${launcher_pid}" "two-child failure race" "${fixture_dir}"
+	if ((simultaneous))
+	then
+		[[ ${wait_status} == 42 || ${wait_status} == 43 ]] || fail "simultaneous failures returned ${wait_status}"
+	else
+		assert_eq 42 "${wait_status}" "first controlled child failure"
+	fi
+	if ((simultaneous)) && grep -Eq "^\+* kill -TERM -- -(${first_pid}|${second_pid})( |$)" "${fixture_dir}/launcher.out"
+	then
+		fail "launcher signalled a child already completed in the simultaneous race"
+	fi
+	assert_pid_gone "${first_pid}" "first failure reap"
+	assert_pid_gone "${second_pid}" "second failure reap"
+}
+
+test_two_fail_race()
+{
+	local iteration stress_iterations=${CAKE_AUTORATE_STRESS_ITERATIONS:-1}
+
+	make_launcher_fixture
+	: > "${config_prefix}/config.first.sh"
+	: > "${config_prefix}/config.second.sh"
+	run_two_fail_race 0
+	for ((iteration=1; iteration<=stress_iterations; iteration++))
+	do
+		run_two_fail_race 1
+	done
+
+	ok "two-failure race and ${stress_iterations} simultaneous stress iterations"
+}
+
+write_real_config()
+{
+	local instance=${1}
+
+	cat > "${config_prefix}/config.${instance}.sh" <<EOF
+dl_if=lo
+ul_if=${iface}
+adjust_dl_shaper_rate=0
+adjust_ul_shaper_rate=0
+pinger_method=ping
+reflectors=(127.0.0.1)
+no_pingers=1
+debug=0
+log_to_file=1
+log_file_path_override="\${CAKE_AUTORATE_TEST_DIR}"
+EOF
+}
+
+make_real_launcher_fixture()
+{
+	command -v unshare >/dev/null 2>&1 || fail "unshare is required for the real daemon tests"
+	make_tmp_dir
+	fake_bin=${fixture_dir}/bin
+	config_prefix=${fixture_dir}/config
+	ns_run=${fixture_dir}/run
+	launcher=${fixture_dir}/launcher.sh
+	mkdir "${fake_bin}" "${config_prefix}" "${ns_run}"
+	render_launcher "${repo_dir}" "${config_prefix}" "${launcher}"
+	if [[ -e /run/current-system ]]
+	then
+		ln -s "$(readlink -f /run/current-system)" "${ns_run}/current-system"
+	fi
+	for iface_path in /sys/class/net/*
+	do
+		iface=${iface_path##*/}
+		[[ ${iface} != lo ]] && break
+	done
+	[[ ${iface:-lo} != lo ]] || fail "real daemon test needs two network interfaces"
+
+	cat > "${fake_bin}/tc" <<'EOF'
+#!/usr/bin/env bash
+if [[ ${CAKE_AUTORATE_TEST_STUBBORN:-0} == 1 ]] && mkdir "${CAKE_AUTORATE_TEST_DIR}/stubborn.lock" 2>/dev/null
+then
+	bash -c 'trap "" TERM; while :; do :; done' </dev/null >/dev/null 2>&1 &
+	printf '%s\n' "${!}" > "${CAKE_AUTORATE_TEST_DIR}/stubborn.pids"
+fi
+printf '%s\n' 'qdisc cake 8001: root refcnt 2 bandwidth 100Mbit noatm overhead 0'
+EOF
+	cat > "${fake_bin}/ping" <<'EOF'
+#!/usr/bin/env bash
+trap 'exit 0' INT TERM
+while :
+do
+	:
+done
+EOF
+	cat > "${fake_bin}/logger" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "${fake_bin}/tc" "${fake_bin}/ping" "${fake_bin}/logger"
+}
+
+start_real_launcher()
+{
+	local trace=${1:-0}
+
+	# The nested Bash expands the exported CAKE_AUTORATE_* variables.
+	# shellcheck disable=SC2016
+	CAKE_AUTORATE_TEST_DIR=${fixture_dir} \
+	CAKE_AUTORATE_TEST_BIN=${fake_bin} \
+	CAKE_AUTORATE_TEST_RUN=${ns_run} \
+	CAKE_AUTORATE_TEST_PATH=${PATH} \
+	CAKE_AUTORATE_TEST_LAUNCHER=${launcher} \
+	CAKE_AUTORATE_TEST_TRACE=${trace} \
+	CAKE_AUTORATE_TEST_STUBBORN=${stubborn_mode:-0} \
+	CAKE_AUTORATE_SCRIPT_PREFIX=${repo_dir} \
+	CAKE_AUTORATE_CONFIG_PREFIX=${config_prefix} \
+		unshare -Urm --map-root-user bash -c '
+			mount --bind "${CAKE_AUTORATE_TEST_RUN}" /run
+			export PATH="${CAKE_AUTORATE_TEST_BIN}:${CAKE_AUTORATE_TEST_PATH}"
+			if [[ ${CAKE_AUTORATE_TEST_TRACE} == 1 ]]
+			then
+				exec bash -x "${CAKE_AUTORATE_TEST_LAUNCHER}"
+			fi
+			exec bash "${CAKE_AUTORATE_TEST_LAUNCHER}"
+		' {test_sleep_fd}>&- > "${fixture_dir}/launcher.out" 2>&1 &
+	launcher_pid=${!}
+	tracked_pids[${launcher_pid}]=1
+}
+
+load_real_instance()
+{
+	local instance=${1} attempt worker_pid
+
+	proc_file=${ns_run}/cake-autorate/${instance}/proc_pids
+	for ((attempt=0; attempt<2000; attempt++))
+	do
+		grep -q '^main=[0-9][0-9]*$' "${proc_file}" 2>/dev/null && break
+		pause 0.01
+	done
+	grep -q '^main=[0-9][0-9]*$' "${proc_file}" 2>/dev/null || fail "real ${instance} daemon did not publish its main PID"
+	instance_main_pid=$(awk -F= '/^main=/ {print $2}' "${proc_file}")
+	instance_pgid=$(ps -o pgid= -p "${instance_main_pid}" | tr -d ' ')
+	instance_parent_pid=$(ps -o ppid= -p "${instance_main_pid}" | tr -d ' ')
+	assert_eq "${instance_main_pid}" "${instance_pgid}" "${instance} main must lead its process group"
+	assert_eq "${launcher_pid}" "${instance_parent_pid}" "${instance} main must be a direct launcher child"
+	tracked_pids[${instance_main_pid}]=1
+	mapfile -t instance_worker_pids < <(awk -F= '/^[^=]+=-?[0-9]+$/ && $1 != "main" {gsub(/^-/, "", $2); print $2}' "${proc_file}")
+	for worker_pid in "${instance_worker_pids[@]}"
+	do
+		tracked_pids[${worker_pid}]=1
+	done
+}
+
+assert_group_gone()
+{
+	local pgid=${1} context=${2} attempt pid
+
+	for ((attempt=0; attempt<200; attempt++))
+	do
+		if ! kill -0 -- "-${pgid}" 2>/dev/null
+		then
+			for pid in "${!tracked_pids[@]}"
+			do
+				kill -0 "${pid}" 2>/dev/null || unset "tracked_pids[${pid}]"
+			done
+			return
+		fi
+		pause 0.01
+	done
+	fail "${context}: process group ${pgid} still has members"
+}
+
+test_real_launcher_fatal_and_sigkill()
+{
+	local fatal_main fatal_pgid killed_main killed_pgid worker_pgid worker_pid
+	local -a worker_pids
+
+	make_real_launcher_fixture
+	write_real_config primary
+	start_real_launcher
+	load_real_instance primary
+	fatal_main=${instance_main_pid}
+	fatal_pgid=${instance_pgid}
+	printf '%s\n' 'synthetic fatal stderr from real launcher test' > "/proc/${fatal_main}/fd/2"
+	wait_with_timeout "${launcher_pid}" "real launcher fatal stderr" "${fixture_dir}"
+	assert_eq 1 "${wait_status}" "real launcher fatal stderr status"
+	assert_group_gone "${fatal_pgid}" "fatal daemon group cleanup"
+
+	make_real_launcher_fixture
+	write_real_config primary
+	start_real_launcher
+	load_real_instance primary
+	killed_main=${instance_main_pid}
+	killed_pgid=${instance_pgid}
+	worker_pids=("${instance_worker_pids[@]}")
+	((${#worker_pids[@]} >= 3)) || fail "real daemon SIGKILL fixture exposed fewer than three workers"
+	for worker_pid in "${worker_pids[@]}"
+	do
+		worker_pgid=$(ps -o pgid= -p "${worker_pid}" | tr -d ' ')
+		assert_eq "${killed_pgid}" "${worker_pgid}" "real daemon worker must remain in its instance PGID"
+	done
+	kill -KILL "${killed_main}"
+	wait_with_timeout "${launcher_pid}" "real daemon main SIGKILL" "${fixture_dir}"
+	assert_eq 137 "${wait_status}" "real daemon main SIGKILL status"
+	assert_group_gone "${killed_pgid}" "SIGKILL daemon group cleanup"
+	for worker_pid in "${worker_pids[@]}"
+	do
+		assert_pid_gone "${worker_pid}" "SIGKILL daemon worker cleanup"
+	done
+
+	ok "real launcher propagates fatal stderr and main SIGKILL without orphans"
+}
+
+test_real_launcher_stopped_instances()
+{
+	local sibling_pgid victim_main victim_pgid stopped_pgid
+
+	make_real_launcher_fixture
+	write_real_config sibling
+	write_real_config victim
+	start_real_launcher
+	load_real_instance sibling
+	sibling_pgid=${instance_pgid}
+	load_real_instance victim
+	victim_main=${instance_main_pid}
+	victim_pgid=${instance_pgid}
+	kill -STOP -- "-${sibling_pgid}"
+	kill -KILL "${victim_main}"
+	wait_with_timeout "${launcher_pid}" "stopped sibling after victim SIGKILL" "${fixture_dir}"
+	assert_eq 137 "${wait_status}" "stopped sibling victim SIGKILL status"
+	assert_group_gone "${sibling_pgid}" "stopped sibling group cleanup"
+	assert_group_gone "${victim_pgid}" "killed victim group cleanup"
+
+	make_real_launcher_fixture
+	write_real_config primary
+	start_real_launcher
+	load_real_instance primary
+	stopped_pgid=${instance_pgid}
+	kill -STOP -- "-${stopped_pgid}"
+	kill -TERM "${launcher_pid}"
+	wait_with_timeout "${launcher_pid}" "operator TERM with stopped daemon" "${fixture_dir}"
+	assert_eq 0 "${wait_status}" "operator TERM with stopped daemon status"
+	assert_group_gone "${stopped_pgid}" "operator TERM stopped group cleanup"
+
+	ok "stopped real daemon groups resume, terminate and never deadlock"
+}
+
+test_real_launcher_kill_escalation()
+{
+	local elapsed_us main_pgid start_us stubborn_pid stubborn_pgid
+
+	make_real_launcher_fixture
+	write_real_config primary
+	stubborn_mode=1
+	start_real_launcher 1
+	load_real_instance primary
+	main_pgid=${instance_pgid}
+	wait_for_file "${fixture_dir}/stubborn.pids" || fail "stubborn worker did not start"
+	read -r stubborn_pid < "${fixture_dir}/stubborn.pids"
+	tracked_pids[${stubborn_pid}]=1
+	stubborn_pgid=$(ps -o pgid= -p "${stubborn_pid}" | tr -d ' ')
+	assert_eq "${main_pgid}" "${stubborn_pgid}" "stubborn worker must inherit daemon PGID"
+	start_us=${EPOCHREALTIME/.}
+	kill -TERM "${launcher_pid}"
+	wait_with_timeout "${launcher_pid}" "stubborn worker KILL escalation" "${fixture_dir}"
+	((elapsed_us=10#${EPOCHREALTIME/.} - 10#${start_us}))
+	assert_eq 0 "${wait_status}" "operator TERM with stubborn worker status"
+	((elapsed_us < 6000000)) || fail "stubborn worker cleanup exceeded six seconds"
+	grep -Eq "kill -KILL -- -${main_pgid}( |$)" "${fixture_dir}/launcher.out" || fail "launcher did not escalate stubborn group to KILL"
+	assert_pid_gone "${stubborn_pid}" "stubborn worker KILL cleanup"
+	assert_group_gone "${main_pgid}" "stubborn worker group cleanup"
+
+	ok "TERM-ignoring real worker is KILLed within the bounded cleanup"
+}
+
+test_term_during_config_discovery
+test_sigint_in_foreground_pty
+test_child_failure_and_all_zero
+test_two_fail_race
+test_real_launcher_fatal_and_sigkill
+test_real_launcher_stopped_instances
+test_real_launcher_kill_escalation

--- a/tests/fixtures/blocking-uci.sh
+++ b/tests/fixtures/blocking-uci.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # CAKE_AUTORATE_TEST_DIR is supplied by fatal-status.sh.
+
+case ${1}:${2:-} in
+	show:cake-autorate)
+		: > "${CAKE_AUTORATE_TEST_DIR}/discovery.ready"
+		while [[ ! -e ${CAKE_AUTORATE_TEST_DIR}/discovery.release ]]
+		do
+			:
+		done
+		printf '%s\n' "cake-autorate.primary.enabled='1'"
+		;;
+	get:cake-autorate.primary.enabled)
+		printf '%s\n' 1
+		;;
+	show:cake-autorate.primary)
+		printf '%s\n' "cake-autorate.primary.enabled='1'"
+		;;
+	*)
+		exit 1
+		;;
+esac

--- a/tests/fixtures/fake-cake.sh
+++ b/tests/fixtures/fake-cake.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # Variables are supplied by fatal-status.sh.
+
+instance=${1##*/config.}
+instance=${instance%.sh}
+
+record_pid()
+{
+	printf '%s %s\n' "$$" "${PPID}" > "${CAKE_AUTORATE_TEST_DIR}/${instance}.pids"
+	: > "${CAKE_AUTORATE_TEST_DIR}/${instance}.ready"
+}
+
+wait_for_path()
+{
+	while [[ ! -e ${1} ]]
+	do
+		:
+	done
+}
+
+busy_wait_us()
+{
+	local start_us=${EPOCHREALTIME/.}
+
+	while ((10#${EPOCHREALTIME/.} - 10#${start_us} < ${1}))
+	do
+		:
+	done
+}
+
+idle()
+{
+	trap 'exit 0' INT TERM
+	while :
+	do
+		:
+	done
+}
+
+record_pid
+case ${CAKE_AUTORATE_TEST_MODE} in
+	failure)
+		if [[ ${instance} == fail ]]
+		then
+			wait_for_path "${CAKE_AUTORATE_TEST_DIR}/slow.ready"
+			exit 42
+		fi
+		idle
+		;;
+	all-zero)
+		if [[ ${instance} == slow ]]
+		then
+			busy_wait_us 100000
+		fi
+		: > "${CAKE_AUTORATE_TEST_DIR}/${instance}.done"
+		exit 0
+		;;
+	two-fail)
+		wait_for_path "${CAKE_AUTORATE_TEST_DIR}/release"
+		if [[ ${instance} == first ]]
+		then
+			: > "${CAKE_AUTORATE_TEST_DIR}/first.exiting"
+			exit 42
+		fi
+		wait_for_path "${CAKE_AUTORATE_TEST_DIR}/first.exiting"
+		[[ ${CAKE_AUTORATE_TEST_SIMULTANEOUS:-0} == 1 ]] || busy_wait_us 100000
+		: > "${CAKE_AUTORATE_TEST_DIR}/second.exiting"
+		exit 43
+		;;
+	*)
+		: > "${CAKE_AUTORATE_TEST_DIR}/cake.started"
+		exit 99
+		;;
+esac

--- a/tests/fixtures/pty-runner.py
+++ b/tests/fixtures/pty-runner.py
@@ -1,0 +1,40 @@
+import os
+import pty
+import signal
+import sys
+import time
+
+launcher, test_dir, path = sys.argv[1:]
+pid, master = pty.fork()
+if pid == 0:
+    env = os.environ.copy()
+    env["CAKE_AUTORATE_TEST_DIR"] = test_dir
+    env["CAKE_AUTORATE_TEST_MODE"] = "unexpected"
+    env["PATH"] = path
+    os.execvpe("bash", ["bash", launcher], env)
+
+deadline = time.monotonic() + 5
+while not os.path.exists(os.path.join(test_dir, "discovery.ready")):
+    if time.monotonic() >= deadline:
+        os.killpg(pid, signal.SIGKILL)
+        os.waitpid(pid, 0)
+        sys.exit(124)
+    time.sleep(0.01)
+
+os.write(master, b"\x03")
+open(os.path.join(test_dir, "discovery.release"), "w").close()
+deadline = time.monotonic() + 5
+while True:
+    waited, result = os.waitpid(pid, os.WNOHANG)
+    if waited:
+        break
+    if time.monotonic() >= deadline:
+        os.killpg(pid, signal.SIGKILL)
+        _, result = os.waitpid(pid, 0)
+        break
+    time.sleep(0.01)
+os.close(master)
+if os.WIFEXITED(result):
+    print(os.WEXITSTATUS(result))
+else:
+    print(128 + os.WTERMSIG(result))


### PR DESCRIPTION
## Summary

- propagate fatal daemon and worker failures through `launcher.sh` instead of reporting every shutdown as success
- run each cake-autorate instance in a dedicated process group so cleanup also reaches descendants after a main process is killed
- keep operator `SIGINT`/`SIGTERM` shutdowns successful while bounding cleanup of stopped or signal-resistant groups
- require Bash 5.1 for `wait -n -f -p` and add focused process-lifecycle regressions

## Root cause

The launcher waited for all wrappers and then exited successfully, regardless of why an instance stopped. Fatal paths in `cake-autorate.sh` also signalled the main shell without preserving a failure status. As a result, service managers could see a clean exit after an internal fatal error.

Tracking only the immediate wrapper PIDs was insufficient for abnormal termination: if a main process was killed (for example by OOM/SIGKILL), its monitor or pinger descendants could survive. A stopped sibling could also make an unbounded PID-based cleanup wait forever.

## Implementation

- `cake-autorate.sh` records fatal status before requesting shutdown and preserves it through cleanup
- `launcher.sh` starts direct children as dedicated process groups and uses `wait -n -f -p` to identify the first completed instance
- group cleanup is bounded: `TERM`, `CONT`, a grace interval, then `KILL` and a final bounded poll
- reaped children are removed from the active set before other groups are signalled
- normal operator signals remain status 0; fatal child status is returned to the service manager

## Tests

- Bash syntax and ShellCheck (`--severity=warning`)
- full lifecycle suite on Bash 5.3 and Bash 5.1.16
- 200 simultaneous-exit stress iterations
- real-daemon fatal stderr propagation
- killed main process with descendant cleanup
- stopped groups and TERM-resistant worker escalation
- first nonzero, all-zero, and concurrent child exits
- foreground PTY `SIGINT` and normal `SIGTERM`
- no residual test processes; `git diff --check`

The tests run on Linux with GNU Bash. Router-specific runtime validation remains useful during review.

Prepared with assistance from OpenAI Codex.
