### PR TITLE
Propagate a fatal exit status to the service manager

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -94,14 +94,20 @@ fi
 # get valid config overrides
 mapfile -t valid_config_entries < <(grep -E '^[^(#| )].*=' "${SCRIPT_PREFIX}/defaults.sh" | sed -e 's/[\t ]*\#.*//g' -e 's/=.*//g')
 
-trap cleanup_and_killall INT TERM EXIT
+trap 'cleanup_and_killall 0' INT TERM
+trap 'cleanup_and_killall "${?}"' EXIT
 
 cleanup_and_killall()
-{	
+{
+	local exit_status=${1:-0}
+
 	# Do not fail on error for this critical cleanup code
 	set +e
 
 	trap : INT TERM EXIT
+
+	# a fatal error marker (e.g. from intercept_stderr) must surface as a failed exit
+	[[ -n ${run_path:-} && -f ${run_path}/fatal_error ]] && exit_status=1
 	
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
 	
@@ -152,7 +158,7 @@ cleanup_and_killall()
 	log_msg "SYSLOG" "Stopped cake-autorate with PID: ${BASHPID} and config: ${config_path}"
 
 	trap - INT TERM EXIT
-	exit
+	exit "${exit_status}"
 }
 
 log_msg()
@@ -844,6 +850,7 @@ change_state_main()
 		*)
 
 			log_msg "ERROR" "Received unrecognized main state change request: ${main_next_state}. Exiting now."
+			[[ -n ${run_path:-} ]] && : > "${run_path}/fatal_error" 2>/dev/null
 			kill $$ 2>/dev/null
 			;;
 	esac
@@ -857,6 +864,7 @@ intercept_stderr()
 	while read -r error
 	do
 		log_msg "ERROR" "${error}"
+		[[ -n ${run_path:-} ]] && : > "${run_path}/fatal_error" 2>/dev/null
 		kill $$ 2>/dev/null
 	done
 }

--- a/launcher.sh.template
+++ b/launcher.sh.template
@@ -34,10 +34,14 @@ fi
 
 cake_instance_pids=()
 
-trap kill_cake_instances INT TERM EXIT
+trap 'kill_cake_instances 0' INT TERM
+trap 'kill_cake_instances "${?}"' EXIT
 
+# shellcheck disable=SC2329  # invoked via the traps above
 kill_cake_instances()
 {
+	local exit_status=${1:-0}
+
 	trap - INT TERM EXIT
 
 	echo "Killing all instances of cake one-by-one now."
@@ -47,6 +51,7 @@ kill_cake_instances()
 		kill "${cake_instance_pids[${cake_instance}]}" 2>/dev/null || true
 	done
 	wait
+	exit "${exit_status}"
 }
 
 for cake_instance in "${cake_instances[@]}"
@@ -54,4 +59,11 @@ do
 	%%SCRIPT_PREFIX%%/cake-autorate.sh "${cake_instance}" &
 	cake_instance_pids+=(${!})
 done
-wait
+
+# propagate a fatal instance exit so the service manager can restart on failure
+launcher_exit_status=0
+for cake_instance_pid in "${cake_instance_pids[@]}"
+do
+	wait "${cake_instance_pid}" || launcher_exit_status=1
+done
+exit "${launcher_exit_status}"


### PR DESCRIPTION
Second half of the #399/#400 cleanup (see #402's apology — same story, minimal hand-checked version).

The bug: a daemon killed by an internal error exits 0. `intercept_stderr` kills the main PID, the TERM trap runs `cleanup_and_killall`, and its bare `exit` reports success; the launcher's final `wait` then also returns 0. So `Restart=on-failure` never fires and the WAN quietly loses its shaper — this is exactly how I originally hit the clock-step bug that became #392: the daemon died mid-run and systemd considered it a clean stop.

Fix: `cleanup_and_killall` preserves the dying status (operator INT/TERM stays 0), the two fatal paths drop a `fatal_error` marker in the run dir that forces a non-zero exit, and the launcher waits per-instance and exits 1 when any instance dies fatally.

Verified with a rendered-launcher harness: on master a fatal instance yields launcher exit 0 (and operator TERM yields 143); with the fix they yield 1 and 0. `bash -n` clean, shellcheck identical to master. Out of scope, unchanged: the launcher still waits for all instances before exiting, and descendants of a SIGKILLed main are not reaped.
