### PR TITLE
Reset reflector response deadline on activation

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -703,14 +703,12 @@ replace_pinger_reflector()
 			retained_ul_owd_baselines_us[${bad_reflector}]=${ul_owd_baselines_us[pinger]}
 			retained_dl_owd_delta_ewmas_us[${bad_reflector}]=${dl_owd_delta_ewmas_us[pinger]}
 			retained_ul_owd_delta_ewmas_us[${bad_reflector}]=${ul_owd_delta_ewmas_us[pinger]}
-			retained_last_timestamp_reflectors_us[${bad_reflector}]=${last_timestamp_reflectors_us[pinger]}
 		else
 			log_msg "DEBUG" "Discarding reflector stats associated with ${bad_reflector}"
 			unset "retained_dl_owd_baselines_us[${bad_reflector}]"
 			unset "retained_ul_owd_baselines_us[${bad_reflector}]"
 			unset "retained_dl_owd_delta_ewmas_us[${bad_reflector}]"
 			unset "retained_ul_owd_delta_ewmas_us[${bad_reflector}]"
-			unset "retained_last_timestamp_reflectors_us[${bad_reflector}]"
 		fi
 
 		reflectors[pinger]=${new_reflector}
@@ -724,7 +722,7 @@ replace_pinger_reflector()
 		ul_owd_baselines_us[pinger]=${retained_ul_owd_baselines_us[${new_reflector}]:-100000}
 		dl_owd_delta_ewmas_us[pinger]=${retained_dl_owd_delta_ewmas_us[${new_reflector}]:-0}
 		ul_owd_delta_ewmas_us[pinger]=${retained_ul_owd_delta_ewmas_us[${new_reflector}]:-0}
-		last_timestamp_reflectors_us[pinger]=${retained_last_timestamp_reflectors_us[${new_reflector}]:-${t_start_us}}
+		last_timestamp_reflectors_us[pinger]=${t_start_us}
 
 		((pingers_active)) && start_pinger "${pinger}"
 	else
@@ -1278,8 +1276,7 @@ declare -A pinger_by_reflector \
 retained_dl_owd_baselines_us \
 retained_ul_owd_baselines_us \
 retained_dl_owd_delta_ewmas_us \
-retained_ul_owd_delta_ewmas_us \
-retained_last_timestamp_reflectors_us
+retained_ul_owd_delta_ewmas_us
 
 base_shaper_rate_kbps[DL]=${base_dl_shaper_rate_kbps} base_shaper_rate_kbps[UL]=${base_ul_shaper_rate_kbps} \
 min_shaper_rate_kbps[DL]=${min_dl_shaper_rate_kbps} min_shaper_rate_kbps[UL]=${min_ul_shaper_rate_kbps} \
@@ -1373,10 +1370,6 @@ t_last_reflector_health_check_us=${t_start_us} \
 t_sustained_connection_idle_us=0 t_last_connection_idle_us=${t_start_us} reflectors_last_timestamp_us=${t_start_us} \
 pingers_t_start_us=${t_start_us} t_last_reflector_replacement_us=${t_start_us} t_last_reflector_comparison_us=${t_start_us}
 
-for ((reflector=0; reflector < no_reflectors; reflector++))
-do
-	retained_last_timestamp_reflectors_us[${reflectors[reflector]}]=${t_start_us}
-done
 for ((pinger=0; pinger < no_pingers; pinger++))
 do
 	last_timestamp_reflectors_us[pinger]=${t_start_us}


### PR DESCRIPTION
### Motivation

Commit [4d5b0e4](https://github.com/lynxthecat/cake-autorate/commit/4d5b0e4073db0beee34fa113f012291a1f687469) introduced retention of per-reflector last-response timestamps across rotations. When a reflector is activated, its pinger slot may therefore inherit a stale timestamp rather than starting its response deadline from the current activation. Until the reflector produces its first response, the health check can consequently treat the entire intervening period as time without a response, record false missed-deadline offences and potentially rotate an otherwise healthy reflector out again. The activation path must instead reset the pinger’s last-seen timestamp while preserving useful retained metrics.

### Description

- Set `last_timestamp_reflectors_us[pinger]` to `t_start_us` when a reflector is activated in `replace_pinger_reflector()` so the response deadline is reset on activation. 
- Remove the `retained_last_timestamp_reflectors_us` array and all initialization, save/restore, and cleanup uses of it. 
- Preserve retention and restoration of reflector baselines (`retained_dl_owd_baselines_us` / `retained_ul_owd_baselines_us`) and delta EWMA arrays (`retained_dl_owd_delta_ewmas_us` / `retained_ul_owd_delta_ewmas_us`) unchanged.

### Testing

- Ran `bash -n cake-autorate.sh` and the script passed shell syntax checks. 
- Ran `git diff --check` and there were no whitespace or diff errors reported. 
- Confirmed removal of `retained_last_timestamp_reflectors_us` with `rg` and verified the local diff shows only the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8586c12538832e9ffda701c113591b)