### PR TITLE
Fix setup self-replacement commit reuse

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -141,15 +141,18 @@ main() {
 	mkdir -p "${SCRIPT_PREFIX}" "${CONFIG_PREFIX}"
 
 	# Get the latest commit to download
-	[ -z "${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT:-}" ] && \
+	if [ -z "${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT:-}" ]
+	then
 		if [ "${MY_OS}" = "openwrt" ] || [ "${MY_OS}" = "asuswrt" ]
 		then
 			JSON_CMD="jsonfilter -e @.sha"
 		else
 			JSON_CMD="jq -r .sha"
 		fi
-		commit=$(download_url "${API_URL}" | ${JSON_CMD}) || \
+		commit=$(download_url "${API_URL}" | ${JSON_CMD})
+	else
 		commit="${__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT}"
+	fi
 	if [ -z "${commit:-}" ];
 	then
 		printf >&2 "Invalid operation occurred, commit variable should not be empty"


### PR DESCRIPTION
Commit 0fa5118 introduced OS-specific JSON parsing for the GitHub commit lookup, but left the `commit=$(... | ${JSON_CMD})` assignment outside the conditional which checks whether `__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT` is already set.

During setup.sh self-replacement, the restarted script receives the preserved commit in `__CAKE_AUTORATE_SETUP_SH_EXEC_COMMIT`. The lookup branch is therefore skipped, so `JSON_CMD` is never initialised. With `set -u`, the subsequent command then reports:

```
JSON_CMD: parameter not set
```

The following `||` fallback happens to recover by reusing the preserved commit, so installation can still complete, but the error is spurious and the restarted setup unnecessarily attempts to execute the commit lookup path.

Replace the compact `&&` / `||` construct with an explicit conditional: perform the GitHub lookup and select `jsonfilter` or `jq` only on the initial invocation, and directly reuse the preserved commit after self-replacement.

This restores the intended pre-0fa5118 behaviour while retaining Debian/Ubuntu support.