### PR TITLE
Preserve MQTT publisher configuration across upgrades

### DIFF
--- a/mqtt-publisher.config.sh
+++ b/mqtt-publisher.config.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+# MQTT broker settings used by mqtt-publisher.sh.
+# This file is preserved by setup.sh across cake-autorate upgrades.
+
+MQTT_HOST=""
+MQTT_PORT=""
+MQTT_USER=""
+MQTT_PASS=""

--- a/mqtt-publisher.sh
+++ b/mqtt-publisher.sh
@@ -211,7 +211,12 @@ publish_stats()
 }
 
 SCRIPT_PREFIX="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)"
-CONFIG_PREFIX="${SCRIPT_PREFIX}"
+CONFIG_PREFIX="${CAKE_AUTORATE_CONFIG_PREFIX:-${SCRIPT_PREFIX}}"
+
+if [[ -r ${CONFIG_PREFIX}/mqtt-publisher.config.sh ]]; then
+    # shellcheck source=mqtt-publisher.config.sh
+    . "${CONFIG_PREFIX}/mqtt-publisher.config.sh"
+fi
 
 declare -A seen_log_dir=()
 log_dirs=()

--- a/setup.sh
+++ b/setup.sh
@@ -232,6 +232,14 @@ main() {
 		mv "${tmp}/config.primary.sh" config.primary.sh
 	fi
 
+	# Install the MQTT publisher configuration only if one is not already present
+	if [ -f mqtt-publisher.config.sh ]
+	then
+		rm -f "${tmp}/mqtt-publisher.config.sh"
+	else
+		mv "${tmp}/mqtt-publisher.config.sh" mqtt-publisher.config.sh
+	fi
+
 	# remove old program files from cake-autorate directory
 	cd "${SCRIPT_PREFIX}"
 	old_fnames="cake-autorate.sh cake-autorate_defaults.sh cake-autorate_launcher.sh cake-autorate_lib.sh cake-autorate_setup.sh"


### PR DESCRIPTION
The MQTT publisher settings currently live in `mqtt-publisher.sh`, which `setup.sh` replaces on every upgrade. This means locally configured broker settings are lost after reinstalling or updating cake-autorate.

This change adds a dedicated `mqtt-publisher.config.sh`, has `mqtt-publisher.sh` source it from the configuration directory, and makes `setup.sh` install the default file only when one is not already present.

The filename does not match `config.*.sh`, so it is not treated as a cake-autorate instance configuration. Existing MQTT publisher configuration is therefore preserved across normal setup upgrades.