### PR TITLE
Restart unresponsive pingers independently of stall state

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -615,7 +615,7 @@ start_pingers()
 			kill $$ 2>/dev/null
 			;;
 	esac
-	pingers_active=1
+	pingers_active=1 t_last_start_pingers_us=${EPOCHREALTIME/.}
 }
 
 sleep_until_next_pinger_time_slot()
@@ -1892,6 +1892,14 @@ do
 
 				log_msg "DEBUG" "load check is: (( ${achieved_rate_kbps[DL]} kbps > ${connection_stall_thr_kbps} kbps for download && ${achieved_rate_kbps[UL]} kbps > ${connection_stall_thr_kbps} kbps for upload ))"
 
+				if (( t_start_us - reflectors_last_timestamp_us >= global_ping_response_timeout_us &&
+					t_start_us - t_last_start_pingers_us >= global_ping_response_timeout_us ))
+				then
+					log_msg "DEBUG" "Restarting pingers."
+					stop_pingers
+					start_pingers
+				fi
+
 				# non-zero load so despite no reflector response within stall interval, the connection not considered to have stalled
 				# and therefore resume normal operation
 				if (( achieved_rate_kbps[DL] > connection_stall_thr_kbps && achieved_rate_kbps[UL] > connection_stall_thr_kbps ))
@@ -2053,6 +2061,11 @@ do
 				global_ping_response_timeout=1
 				((min_shaper_rates_enforcement)) && set_min_shaper_rates
 				log_msg "SYSLOG" "Warning: Configured global ping response timeout: ${global_ping_response_timeout_s} seconds exceeded."
+			fi
+
+			if (( t_start_us - reflectors_last_timestamp_us >= global_ping_response_timeout_us &&
+				t_start_us - t_last_start_pingers_us >= global_ping_response_timeout_us ))
+			then
 				log_msg "DEBUG" "Restarting pingers."
 				stop_pingers
 				start_pingers


### PR DESCRIPTION
Fixes #385.

### Motivation

- Pinger processes can die or stop producing reflector responses while traffic causes the main state to leave `STALL`.
- The existing restart logic only ran inside the `STALL`-specific global timeout handling, so a failed restart during an outage could be missed once the state returned to `RUNNING`.

### Description

- Add `t_last_start_pingers_us` and update it in `start_pingers()` only when pingers are actually started, so repeated recovery attempts are rate-limited.
- In `RUNNING`, reuse the existing no-reflector-response path to restart pingers once both the global response timeout and the retry interval since the last start have elapsed.
- In `STALL`, keep the existing one-shot `global_ping_response_timeout` handling, including the `SYSLOG` warning and optional `min_shaper_rates_enforcement`, while separately retrying pinger starts at the configured global timeout interval.
- Keep recovery out of the normal healthy-response path and out of `IDLE`, where pingers are intentionally stopped.

### Testing

- `bash -n cake-autorate.sh`
- `git diff --check`
- `shellcheck` was not available in the Codex environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8c4d8a797c832eb3df9df1ff032fc9)