### PR TITLE
Experiment: reduce buffered log collector CPU using per-record framing

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -390,7 +390,6 @@ flush_log_pipe()
 
 log_file_waker()
 {
-	printf -v log_file_buffer_timeout_s %.3f "${log_file_buffer_timeout_ms}e-3"
 	while kill -0 "${proc_pids['maintain_log_file']}" 2>/dev/null
 	do
 		sleep_s "${log_file_buffer_timeout_s}"
@@ -1238,6 +1237,7 @@ then
 		log_file_max_time_s=log_file_max_time_mins*60,
 		log_file_max_size_bytes=log_file_max_size_KB*1024
 	))
+	printf -v log_file_buffer_timeout_s %.3f "${log_file_buffer_timeout_ms}e-3"
 	exec {log_fd}<> <(:)
 	maintain_log_file &
 	proc_pids['maintain_log_file']=${!}

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -115,6 +115,7 @@ cleanup_and_killall()
 
 	((terminate_maintain_log_file_timeout_ms=log_file_buffer_timeout_ms+500))
 	terminate "${proc_pids['maintain_log_file']:-}" "${terminate_maintain_log_file_timeout_ms}"
+	terminate "${proc_pids['log_file_waker']:-}"
 
 	[[ -d ${run_path} ]] && rm -r "${run_path}"
 	rmdir /var/run/cake-autorate 2>/dev/null
@@ -154,7 +155,7 @@ log_msg()
 {
 	# send logging message to stdout, log file fifo, log file and/or system logger
 
-	local type=${1} msg=${2} instance_id=${instance_id:-"unknown"} log_timestamp=${EPOCHREALTIME}
+	local type=${1} msg=${2} instance_id=${instance_id:-"unknown"} log_timestamp=${EPOCHREALTIME} log_frame_payload
 
 	case ${type} in
 
@@ -186,7 +187,17 @@ log_msg()
 	((log_to_file)) || return
 	if (( log_fd >= 0 ))
 	then
-		printf '%s' "${msg}" >&"${log_fd}"
+		if (( ${#msg} <= 4091 ))
+		then
+			printf 'L%04d%s' "${#msg}" "${msg}" >&"${log_fd}"
+		else
+			while [[ -n ${msg} ]]
+			do
+				log_frame_payload=${msg::4091}
+				printf 'L%04d%s' "${#log_frame_payload}" "${log_frame_payload}" >&"${log_fd}"
+				msg=${msg:4091}
+			done
+		fi
 	else
 		printf '%s' "${msg}" >> "${log_file_path}"
 	fi
@@ -319,7 +330,7 @@ export_log_file()
 	log_file_export_path="${log_file_path/.log/_${log_file_export_datetime}.log}"
 	log_msg "DEBUG" "Exporting log file with path: ${log_file_path/.log/_${log_file_export_datetime}.log}"
 
-	flush_log_pipe
+	flush_log_pipe || return 1
 
 	# Now export with or without compression to the appropriate export path
 	if ((log_file_export_compress))
@@ -343,11 +354,52 @@ export_log_file()
 flush_log_pipe()
 {
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
-	while read -r -t 0 -u "${log_fd}"
+	while IFS= read -r -t 0 -u "${log_fd}"
 	do
-		read -r -u "${log_fd}" log_line
-		printf '%s\n' "${log_line}" >&${log_file_fd}
-		((log_file_size_bytes+=${#log_line}))
+		frame_header=""
+		if ! IFS= read -r -N 5 -u "${log_fd}" frame_header
+		then
+			trap - TERM EXIT USR1 USR2
+			printf 'ERROR: incomplete internal log protocol header: %q\n' "${frame_header}" >&"${original_stderr_fd}"
+			return 1
+		fi
+		if [[ ${frame_header} != L[0-9][0-9][0-9][0-9] ]]
+		then
+			trap - TERM EXIT USR1 USR2
+			printf 'ERROR: malformed internal log protocol header: %q\n' "${frame_header}" >&"${original_stderr_fd}"
+			return 1
+		fi
+		frame_length=$((10#${frame_header:1}))
+		if (( frame_length > 4091 ))
+		then
+			trap - TERM EXIT USR1 USR2
+			printf 'ERROR: invalid internal log protocol payload length: %d\n' "${frame_length}" >&"${original_stderr_fd}"
+			return 1
+		fi
+		(( frame_length == 0 )) && continue
+		frame_payload=""
+		if ! IFS= read -r -N "${frame_length}" -u "${log_fd}" frame_payload
+		then
+			trap - TERM EXIT USR1 USR2
+			printf 'ERROR: incomplete internal log protocol payload: expected %d bytes, received %d\n' \
+				"${frame_length}" "${#frame_payload}" >&"${original_stderr_fd}"
+			return 1
+		fi
+		log_chunk+=${frame_payload}
+	done
+	printf '%s' "${log_chunk}" >&${log_file_fd}
+	((log_file_size_bytes+=${#log_chunk}))
+	log_chunk=""
+}
+
+log_file_waker()
+{
+	printf -v log_file_buffer_timeout_s %.3f "${log_file_buffer_timeout_ms}e-3"
+	while kill -0 "${proc_pids['maintain_log_file']}" 2>/dev/null
+	do
+		sleep_s "${log_file_buffer_timeout_s}"
+		kill -0 "${proc_pids['maintain_log_file']}" 2>/dev/null || break
+		printf 'L0000' >&"${log_fd}"
 	done
 }
 
@@ -361,7 +413,7 @@ maintain_log_file()
 
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
 
-	printf -v log_file_buffer_timeout_s %.1f "${log_file_buffer_timeout_ms}e-3"
+	log_chunk=""
 
 	while :
 	do
@@ -375,17 +427,50 @@ maintain_log_file()
 
 		while :
 		do
-			read -r -N "${log_file_buffer_size_B}" -t "${log_file_buffer_timeout_s}" -u "${log_fd}" log_chunk
-		
-			printf '%s' "${log_chunk}" >&${log_file_fd}
-
-			((log_file_size_bytes+=${#log_chunk}))
+			frame_header=""
+			if ! IFS= read -r -N 5 -u "${log_fd}" frame_header
+			then
+				trap - TERM EXIT USR1 USR2
+				printf 'ERROR: incomplete internal log protocol header: %q\n' "${frame_header}" >&"${original_stderr_fd}"
+				exit 1
+			fi
+			if [[ ${frame_header} != L[0-9][0-9][0-9][0-9] ]]
+			then
+				trap - TERM EXIT USR1 USR2
+				printf 'ERROR: malformed internal log protocol header: %q\n' "${frame_header}" >&"${original_stderr_fd}"
+				exit 1
+			fi
+			frame_length=$((10#${frame_header:1}))
+			if (( frame_length > 4091 ))
+			then
+				trap - TERM EXIT USR1 USR2
+				printf 'ERROR: invalid internal log protocol payload length: %d\n' "${frame_length}" >&"${original_stderr_fd}"
+				exit 1
+			fi
+			if (( frame_length > 0 ))
+			then
+				frame_payload=""
+				if ! IFS= read -r -N "${frame_length}" -u "${log_fd}" frame_payload
+				then
+					trap - TERM EXIT USR1 USR2
+					printf 'ERROR: incomplete internal log protocol payload: expected %d bytes, received %d\n' \
+						"${frame_length}" "${#frame_payload}" >&"${original_stderr_fd}"
+					exit 1
+				fi
+				log_chunk+=${frame_payload}
+			fi
+			if (( ${#log_chunk} >= log_file_buffer_size_B || frame_length == 0 ))
+			then
+				printf '%s' "${log_chunk}" >&${log_file_fd}
+				((log_file_size_bytes+=${#log_chunk}))
+				log_chunk=""
+			fi
 
 			# Verify log file time < configured maximum
 			if (( SECONDS - t_log_file_start_s > log_file_max_time_s ))
 			then
 				log_msg "DEBUG" "log file maximum time: ${log_file_max_time_mins} minutes has elapsed so flushing and rotating log file."
-				flush_log_pipe
+				flush_log_pipe || exit 1
 				rotate_log_file
 				break
 			# Verify log file size < configured maximum
@@ -393,7 +478,7 @@ maintain_log_file()
 			then
 				((log_file_size_KB=log_file_size_bytes/1024))
 				log_msg "DEBUG" "log file size: ${log_file_size_KB} KB has exceeded configured maximum: ${log_file_max_size_KB} KB so flushing and rotating log file."
-				flush_log_pipe
+				flush_log_pipe || exit 1
 				rotate_log_file
 				break
 			fi
@@ -405,18 +490,18 @@ maintain_log_file()
 					;;
 				*KILL*)
 					log_msg "DEBUG" "received log file kill signal so flushing log and exiting."
-					flush_log_pipe
+					flush_log_pipe || exit 1
 					trap - TERM EXIT
 					exit
 					;;
 				*EXPORT*)
 					log_msg "DEBUG" "received log file export signal so exporting log file."
-					export_log_file
+					export_log_file || exit 1
 					signal="${signal//EXPORT}"
 					;;
 				*RESET*)
 					log_msg "DEBUG" "received log file reset signal so flushing log and resetting log file."
-					flush_log_pipe
+					flush_log_pipe || exit 1
 					reset_log_file
 					signal="${signal//RESET}"
 					break
@@ -1160,13 +1245,15 @@ then
 	exec {log_fd}<> <(:)
 	maintain_log_file &
 	proc_pids['maintain_log_file']=${!}
+	log_file_waker &
+	proc_pids['log_file_waker']=${!}
 fi
 
 # Redirect stdout to the log pipe when it is not being output directly
 if ! ((print_to_stdout))
 then
-	echo "stdout not a terminal so redirecting output to: ${log_file_path}"
-	((log_to_file)) && exec 1>&${log_fd}
+	echo "stdout not a terminal; disabling unexpected stdout output"
+	((log_to_file)) && exec 1>/dev/null
 fi
 
 # Initialize rx_bytes_path and tx_bytes_path if not set

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -454,7 +454,8 @@ maintain_log_file()
 				fi
 				log_chunk+=${frame_payload}
 			fi
-			if (( ${#log_chunk} >= log_file_buffer_size_B || frame_length == 0 ))
+			if (( ${#log_chunk} > 0 &&
+				(${#log_chunk} >= log_file_buffer_size_B || frame_length == 0) ))
 			then
 				printf '%s' "${log_chunk}" >&${log_file_fd}
 				((log_file_size_bytes+=${#log_chunk}))

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -155,7 +155,7 @@ log_msg()
 {
 	# send logging message to stdout, log file fifo, log file and/or system logger
 
-	local type=${1} msg=${2} instance_id=${instance_id:-"unknown"} log_timestamp=${EPOCHREALTIME} log_frame_payload
+	local type=${1} msg=${2} instance_id=${instance_id:-"unknown"} log_timestamp=${EPOCHREALTIME}
 
 	case ${type} in
 
@@ -187,17 +187,13 @@ log_msg()
 	((log_to_file)) || return
 	if (( log_fd >= 0 ))
 	then
-		if (( ${#msg} <= 4091 ))
+		if (( ${#msg} > 4091 ))
 		then
-			printf 'L%04d%s' "${#msg}" "${msg}" >&"${log_fd}"
-		else
-			while [[ -n ${msg} ]]
-			do
-				log_frame_payload=${msg::4091}
-				printf 'L%04d%s' "${#log_frame_payload}" "${log_frame_payload}" >&"${log_fd}"
-				msg=${msg:4091}
-			done
+			printf 'ERROR: rejected internal log record of %d bytes; maximum is 4091 bytes\n' \
+				"${#msg}" >&"${original_stderr_fd}"
+			return 1
 		fi
+		printf 'L%04d%s' "${#msg}" "${msg}" >&"${log_fd}"
 	else
 		printf '%s' "${msg}" >> "${log_file_path}"
 	fi


### PR DESCRIPTION
## Outcome

> [!NOTE]
> This is an archived experiment and is not recommended for merging.

The implementation correctly reduced CPU use for saturated log streams, but later paced testing showed that per-record framing increased CPU use at the rates representative of cake-autorate. It is retained here as a record of the investigation. PR #415 explored fixed padding as a follow-on alternative and reached the same overall conclusion.

## Motivation

The buffered log-file collector consumed log data using:

```bash
read -N "${log_file_buffer_size_B}" \
	-t "${log_file_buffer_timeout_s}"
```

Combining an exact-length read with a timeout makes Bash's data-consuming path expensive under continuously available input. This experiment replaced that timed read with a small internal framing protocol so that the collector could consume headers and payloads using untimed exact reads.

## Experimental implementation

Each accepted formatted log record is written atomically to the internal pipe as:

```text
Ldddd<payload>
```

`Ldddd` is a fixed five-byte header whose four decimal digits declare the payload length.

The implementation:

- accepts payloads up to 4091 bytes so that each complete frame remains within Linux's 4096-byte `PIPE_BUF`;
- reads and validates an untimed five-byte header, followed by an untimed exact payload read;
- accumulates payloads in the existing file-output buffer;
- uses a periodic `L0000` control frame from `log_file_waker` at the configured 500 ms default interval;
- writes a non-empty partial buffer on `L0000`, while still performing rotation and signal checks when the buffer is empty;
- excludes framing headers and control frames from the log file; and
- rejects oversized records before any partial pipe write.

Final head `c874d15` skips an empty file-output operation on padding-only wakes. It does not alter the ordinary per-record framing work.

## CPU benchmarks

The initial unpaced burst benchmarks showed substantial gains because the original timed read continuously consumed available bytes. A subsequent controlled benchmark used one unreported warm-up and five measured runs, alternated old/new ordering, and verified exact output byte counts.

Paced results used approximately 109-byte records and report median combined producer, collector and waker CPU per 60 seconds:

| Workload | Original timed collector | Framed collector | Difference |
|---|---:|---:|---:|
| Idle | 0.02 s | 0.03 s | +0.01 s |
| 2 records/s | 0.05 s | 0.08 s | +0.03 s |
| 5 records/s | 0.10 s | 0.14 s | +0.04 s |
| 10 records/s | 0.18 s | 0.26 s | +0.08 s |
| 20 records/s | 0.33 s | 0.47 s | +0.14 s |
| 50 records/s | 0.77 s | 1.05 s | +0.28 s |
| 100 records/s | 1.29 s | 1.83 s | +0.54 s |

No steady-rate break-even was observed at or below 100 records/s.

Unpaced burst results were:

| Workload | Original | Framed | Difference |
|---|---:|---:|---:|
| 30,000 × 109-byte records | 1.82 s | 1.56 s | 14.3% lower |
| 4,000 × 4091-byte records | 7.49 s | 0.98 s | 86.9% lower |

The controlled paced benchmark was performed against preceding framed revision `f781539`. The final `c874d15` change only removes an empty output operation on `L0000`; it does not remove the header formatting, header read, validation, decimal parsing or separate payload read responsible for the paced regression.

## Interpretation

Framing removes timeout processing from reads that consume log bytes, but adds work for every ordinary record. That trade-off is favourable under saturation and unfavourable for evenly paced short records. Normal cake-autorate logging is paced, with approximately 20 accepted reflector responses/s under the default six-pinger, 0.3-second configuration.

The experimental mechanism is therefore not suitable as a general CPU optimisation.

## Validation

Validation included:

- `bash -n cake-autorate.sh`;
- `git diff --check`;
- ShellCheck 0.11.0 at warning severity, normally and with sourced files followed;
- concurrent atomic frame writers;
- oversized-record rejection;
- low-volume wake and flush behaviour;
- signal handling;
- rotation, export, reset and graceful-shutdown smoke tests; and
- verification that an empty `L0000` wake does not perform an empty file write.

GitHub reports no repository CI checks for this PR.

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8de104ed6c832e8ab808af6cddd2e4)