### PR TITLE
Experiment: reduce buffered log collector CPU using fixed padding

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -115,6 +115,7 @@ cleanup_and_killall()
 
 	((terminate_maintain_log_file_timeout_ms=log_file_buffer_timeout_ms+500))
 	terminate "${proc_pids['maintain_log_file']:-}" "${terminate_maintain_log_file_timeout_ms}"
+	terminate "${proc_pids['log_file_waker']:-}"
 
 	[[ -d ${run_path} ]] && rm -r "${run_path}"
 	rmdir /var/run/cake-autorate 2>/dev/null
@@ -186,6 +187,16 @@ log_msg()
 	((log_to_file)) || return
 	if (( log_fd >= 0 ))
 	then
+		if [[ ${msg} == *"${log_file_padding_byte}"* ]]
+		then
+			printf 'ERROR: Log record contained the reserved log-pipe padding byte.\n' >&2
+			return 1
+		elif (( ${#msg} > 4096 ))
+		then
+			printf 'ERROR: Log record was %d bytes; maximum atomic log-pipe record size is 4096 bytes.\n' \
+				"${#msg}" >&2
+			return 1
+		fi
 		printf '%s' "${msg}" >&"${log_fd}"
 	else
 		printf '%s' "${msg}" >> "${log_file_path}"
@@ -342,12 +353,35 @@ export_log_file()
 
 flush_log_pipe()
 {
+	local log_chunk
+
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
-	while read -r -t 0 -u "${log_fd}"
+
+	while
+		log_chunk=""
+		IFS= read -r -N "${log_file_buffer_size_B}" \
+			-t 0.01 -u "${log_fd}" log_chunk ||
+			[[ -n ${log_chunk} ]]
 	do
-		read -r -u "${log_fd}" log_line
-		printf '%s\n' "${log_line}" >&${log_file_fd}
-		((log_file_size_bytes+=${#log_line}))
+		log_chunk=${log_chunk//"${log_file_padding_byte}"/}
+
+		if [[ -n ${log_chunk} ]]
+		then
+			printf '%s' "${log_chunk}" >&${log_file_fd}
+			((log_file_size_bytes+=${#log_chunk}))
+		fi
+	done
+}
+
+log_file_waker()
+{
+	trap '' INT
+	trap 'exit' TERM EXIT
+
+	while sleep_s "${log_file_buffer_timeout_s}"
+	do
+		kill -0 "${proc_pids['maintain_log_file']}" 2>/dev/null || break
+		printf '%s' "${log_file_padding}" >&"${log_fd}"
 	done
 }
 
@@ -361,8 +395,6 @@ maintain_log_file()
 
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
 
-	printf -v log_file_buffer_timeout_s %.1f "${log_file_buffer_timeout_ms}e-3"
-
 	while :
 	do
 		exec {log_file_fd}> "${log_file_path}"
@@ -375,11 +407,14 @@ maintain_log_file()
 
 		while :
 		do
-			read -r -N "${log_file_buffer_size_B}" -t "${log_file_buffer_timeout_s}" -u "${log_fd}" log_chunk
-		
-			printf '%s' "${log_chunk}" >&${log_file_fd}
+			IFS= read -r -N "${log_file_buffer_size_B}" -u "${log_fd}" log_chunk
+			log_chunk=${log_chunk//"${log_file_padding_byte}"/}
 
-			((log_file_size_bytes+=${#log_chunk}))
+			if [[ -n ${log_chunk} ]]
+			then
+				printf '%s' "${log_chunk}" >&${log_file_fd}
+				((log_file_size_bytes+=${#log_chunk}))
+			fi
 
 			# Verify log file time < configured maximum
 			if (( SECONDS - t_log_file_start_s > log_file_max_time_s ))
@@ -1157,9 +1192,15 @@ then
 		log_file_max_time_s=log_file_max_time_mins*60,
 		log_file_max_size_bytes=log_file_max_size_KB*1024
 	))
+	log_file_padding_byte=$'\x1e'
+	printf -v log_file_buffer_timeout_s %.3f "${log_file_buffer_timeout_ms}e-3"
+	printf -v log_file_padding '%*s' "${log_file_buffer_size_B}" ''
+	log_file_padding=${log_file_padding// /"${log_file_padding_byte}"}
 	exec {log_fd}<> <(:)
 	maintain_log_file &
 	proc_pids['maintain_log_file']=${!}
+	log_file_waker &
+	proc_pids['log_file_waker']=${!}
 fi
 
 # Redirect stdout to the log pipe when it is not being output directly


### PR DESCRIPTION
## Outcome

> [!NOTE]
> This is an archived experiment and is not recommended for merging.

This PR explored fixed padding as an alternative to the per-record framing in #414. OpenWrt testing showed that it reduced logging-transport CPU when both SUMMARY and detailed DATA records were enabled, but increased CPU during quiescent periods and with SUMMARY alone. The modest detailed-logging benefit does not justify the always-on fixed cost and additional transport complexity.

## Motivation

PR #414 established that removing timeout processing from a continuously busy Bash `read -N` can substantially reduce CPU. Per-record framing nevertheless regressed ordinary paced workloads because each record required header formatting, a header read, validation, parsing and a separate payload read.

This experiment sought to retain an untimed buffered `read -N` while restoring raw record writes and eliminating per-record headers.

## Experimental implementation

The candidate:

- retains one raw atomic pipe write for each accepted formatted log record;
- reserves ASCII Record Separator (`0x1e`) as a transport padding byte;
- rejects a record containing that byte or exceeding the 4096-byte Linux atomic pipe-write limit;
- precomputes one padding block of `log_file_buffer_size_B` bytes;
- has `log_file_waker` write that block every configured timeout interval;
- consumes steady-state data with an untimed `read -N "${log_file_buffer_size_B}"`;
- removes padding before writing and counting real log bytes;
- skips padding-only file writes;
- uses a short timed partial drain only in the exceptional `flush_log_pipe` path; and
- terminates the collector before the waker so a final padding block can release a blocked read during shutdown.

The candidate is the single commit `d03b2e6` over base `2582dff`.

## Correctness validation

Focused external harnesses verified:

- exact preservation of sparse, complete and partial chunks;
- records crossing the 512-byte boundary;
- padding-only wakes and residual-padding removal;
- maximum-size acceptance and oversized rejection;
- reserved-byte rejection;
- multiple concurrent atomic producers;
- TERM while blocked in the untimed read;
- rotation, export, reset and shutdown behaviour; and
- preservation of the established stdout modes.

The OpenWrt benchmark independently verified exact output content after every run and detected no leaked padding.

Static checks included `bash -n cake-autorate.sh` and `git diff --check`. ShellCheck was unavailable in the candidate environment.

## OpenWrt benchmark

The comparison ran on a Linksys RT3200 using the production defaults:

- `log_file_buffer_size_B=512`;
- `log_file_buffer_timeout_ms=500`;
- one 10-second warm-up for each variant and workload;
- five measured 120-second runs with old/new ordering alternated;
- production-shaped SUMMARY and DATA records;
- candidate producer validation included in the measured path; and
- producer, collector and waker CPU accounted separately.

The router exposed usable `/proc/<pid>/stat` clock ticks but not `CLK_TCK`. Results are therefore retained as raw ticks. This prevents conversion to seconds but does not affect same-machine relative comparisons.

| Workload | Original median | Fixed-padding median | Difference |
|---|---:|---:|---:|
| No records | 8 | 37 | +362.5% |
| SUMMARY at approximately 20 records/s | 239 | 265 | +10.9% |
| SUMMARY+DATA at approximately 40 records/s | 473 | 436 | −7.8% |

All five fixed-padding runs were worse than all five original runs for the no-record and SUMMARY workloads. All five were better for SUMMARY+DATA. Exact-output checks passed.

The complete harness and raw measurements are retained in the benchmark comment below.

## Interpretation

The padding design removes the per-record framing cost and substantially reduces collector work for longer DATA records. It nevertheless adds a second process, two periodic 512-byte writes per second, padding-only collector reads and producer validation.

The benchmark measures the isolated logging transport rather than total cake-autorate CPU. Common application processing would make both the regressions and the improvement smaller percentages of whole-application CPU. The no-record case represents the fixed quiescent cost rather than every occasional record produced by a default configuration.

The results are sufficient for the decision: fixed padding is worse for sparse and SUMMARY-only logging and only modestly better for detailed logging. A configuration-dependent dual collector would add still more complexity for a very small whole-application benefit. The original timed collector remains preferable overall.

------

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ffb4c4754832ea2d385f532d78994)