### PR TITLE
Reduce CPU use in buffered log-file collector

### DIFF
--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -20,6 +20,7 @@ cake_autorate_version="3.3.0-PRERELEASE"
 ## main - main process
 ## monitor_achieved_rates - monitor network transfer rates
 ## maintain_log_file - maintain and rotate log file
+## log_file_waker - mark buffered log intervals
 ##
 ## IPC is facilitated via FIFOs in the form of anonymous pipes
 ## thereby to enable transferring data between processes
@@ -97,7 +98,7 @@ mapfile -t valid_config_entries < <(grep -E '^[^(#| )].*=' "${SCRIPT_PREFIX}/def
 trap cleanup_and_killall INT TERM EXIT
 
 cleanup_and_killall()
-{	
+{
 	# Do not fail on error for this critical cleanup code
 	set +e
 
@@ -114,7 +115,11 @@ cleanup_and_killall()
 	terminate "${pinger_pids[*]}"
 
 	((terminate_maintain_log_file_timeout_ms=log_file_buffer_timeout_ms+500))
-	terminate "${proc_pids['maintain_log_file']:-}" "${terminate_maintain_log_file_timeout_ms}"
+	terminate "${proc_pids['maintain_log_file']:-}" \
+		"${terminate_maintain_log_file_timeout_ms}"
+	terminate "${proc_pids['log_file_waker']:-}"
+
+	unset "proc_pids[maintain_log_file]" "proc_pids[log_file_waker]"
 
 	[[ -d ${run_path} ]] && rm -r "${run_path}"
 	rmdir /var/run/cake-autorate 2>/dev/null
@@ -342,26 +347,48 @@ export_log_file()
 
 flush_log_pipe()
 {
+	local log_chunk
+
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
-	while read -r -t 0 -u "${log_fd}"
+	while
+		log_chunk=""
+		IFS= read -r -d '' -t 0.01 -u "${log_fd}" log_chunk ||
+			[[ -n ${log_chunk} ]]
 	do
-		read -r -u "${log_fd}" log_line
-		printf '%s\n' "${log_line}" >&${log_file_fd}
-		((log_file_size_bytes+=${#log_line}))
+		if [[ -n ${log_chunk} ]]
+		then
+			printf '%s' "${log_chunk}" >&${log_file_fd}
+			((log_file_size_bytes+=${#log_chunk}))
+		fi
+	done
+}
+
+log_file_waker()
+{
+	trap '' INT
+	trap 'exit' TERM
+
+	while sleep_s "${log_file_buffer_timeout_s}"
+	do
+		kill -0 "${proc_pids['maintain_log_file']}" 2>/dev/null || break
+		# Bash variables cannot contain NUL, so write the interval marker directly.
+		printf '\0' >&"${log_fd}"
 	done
 }
 
 maintain_log_file()
 {
+	local log_chunk
+	local -a log_chunks
 	signal=""
 	trap '' INT
-	trap 'signal+=KILL' TERM EXIT
+	# Wake a blocked mapfile so it can process the termination request.
+	trap 'signal+=KILL; printf "\0" >&"${log_fd}"' TERM
+	trap 'signal+=KILL' EXIT
 	trap 'signal+=EXPORT' USR1
 	trap 'signal+=RESET' USR2
 
 	log_msg "DEBUG" "Starting: ${FUNCNAME[0]} with PID: ${BASHPID}"
-
-	printf -v log_file_buffer_timeout_s %.1f "${log_file_buffer_timeout_ms}e-3"
 
 	while :
 	do
@@ -375,11 +402,20 @@ maintain_log_file()
 
 		while :
 		do
-			read -r -N "${log_file_buffer_size_B}" -t "${log_file_buffer_timeout_s}" -u "${log_fd}" log_chunk
-		
-			printf '%s' "${log_chunk}" >&${log_file_fd}
-
-			((log_file_size_bytes+=${#log_chunk}))
+			log_chunks=()
+			if ! mapfile -d '' -t -n 1 -u "${log_fd}" log_chunks &&
+				(( ${#log_chunks[@]} == 0 )) && [[ -z ${signal} ]]
+			then
+				printf 'ERROR: Buffered log collector failed while reading the log pipe.\n' >&2
+				trap - TERM EXIT
+				exit 1
+			fi
+			log_chunk=${log_chunks[0]-}
+			if [[ -n ${log_chunk} ]]
+			then
+				printf '%s' "${log_chunk}" >&${log_file_fd}
+				((log_file_size_bytes+=${#log_chunk}))
+			fi
 
 			# Verify log file time < configured maximum
 			if (( SECONDS - t_log_file_start_s > log_file_max_time_s ))
@@ -1157,9 +1193,12 @@ then
 		log_file_max_time_s=log_file_max_time_mins*60,
 		log_file_max_size_bytes=log_file_max_size_KB*1024
 	))
+	printf -v log_file_buffer_timeout_s %.3f "${log_file_buffer_timeout_ms}e-3"
 	exec {log_fd}<> <(:)
 	maintain_log_file &
 	proc_pids['maintain_log_file']=${!}
+	log_file_waker &
+	proc_pids['log_file_waker']=${!}
 fi
 
 # Redirect stdout to the log pipe when it is not being output directly

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1044,6 +1044,12 @@ unset valid_config_entries user_config config_error_count key
 # shellcheck source=config.primary.sh
 . "${config_path}"
 
+if (( 10#${log_file_buffer_timeout_ms} < 50 ))
+then
+	printf 'ERROR: log_file_buffer_timeout_ms must be at least 50 milliseconds. Exiting now.\n' >&2
+	exit 1
+fi
+
 if [[ ${config_path} =~ config\.(.*)\.sh ]]
 then
 	instance_id=${BASH_REMATCH[1]} run_path="/var/run/cake-autorate/${instance_id}"

--- a/defaults.sh
+++ b/defaults.sh
@@ -135,7 +135,6 @@ startup_wait_s=0.0 # number of seconds to wait on startup (e.g. to wait for thin
 
 # *** ADVANCED CONFIGURATION OPTIONS ***
 
-log_file_buffer_size_B=512     # log file buffer size in bytes
 log_file_buffer_timeout_ms=500 # log file buffer timeout in milliseconds
 
 log_file_export_compress=1 # compress log file exports using gzip and append .gz to export filename


### PR DESCRIPTION
## Motivation

The purpose of this change is to reduce the CPU used by cake-autorate’s buffered log-file collector, particularly when statistics logging produces a steady stream of short records.

The current collector uses Bash’s timed byte-consuming read:

```bash
read -r -N "${log_file_buffer_size_B}" \
	-t "${log_file_buffer_timeout_s}" -u "${log_fd}" log_chunk
```

That read completes when either 512 bytes have accumulated or the configured timeout expires. With active `SUMMARY` or `SUMMARY+DATA` logging, the byte threshold can be reached several times within each nominal 500 ms buffering interval. The collector consequently performs multiple timed `read` invocations, and Bash’s timeout processing adds work while input bytes are being consumed.

The objective is to remove that steady-state timeout processing and reduce the number of collector builtin invocations without:

- adding work to every producer record;
- changing the raw producer write;
- changing reflector processing, pingers, `main_fd` or the control loop;
- exceeding the configured maximum sparse-data buffering delay;
- losing, duplicating or reordering log bytes;
- weakening rotation, export, reset or shutdown behavior.

This implementation keeps producer writes unchanged and uses one periodic NUL marker to define each buffering interval. The collector performs one untimed NUL-delimited `mapfile` operation per interval:

```bash
mapfile -d '' -t -n 1 -u "${log_fd}" log_chunks
```

This batches all raw log bytes accumulated before the marker into one array item, avoiding both the original timed data-consuming read and the per-record overhead investigated in the framed experiment.

Preliminary OpenWrt measurements showed:

- for `SUMMARY` at 20 records/s, logger CPU decreased from 17 to 13 ticks and combined benchmark-process CPU decreased from 48 to 44 ticks;
- for `SUMMARY+DATA` at 20 pairs/s, logger CPU decreased from 54 to 31 ticks and combined benchmark-process CPU decreased from 106 to 82 ticks.

These correspond to 23.5% and 42.6% less logger CPU respectively, and 8.3% and 22.6% less combined benchmark-process CPU. They are not measurements of total cake-autorate CPU. Idle results were below useful measurement resolution, and a longer OpenWrt benchmark remains outstanding.

This is the third implementation investigated for this objective. The per-record framing experiment in #414 reduced CPU under saturation but regressed ordinary paced workloads. The fixed-padding experiment in #415 improved heavier logging but introduced greater idle and `SUMMARY`-only overhead. This NUL/`mapfile` design avoids per-record framing and full-block padding.

## Design

A small `log_file_waker` sleeps for `log_file_buffer_timeout_s`, verifies that `maintain_log_file` remains alive, and writes exactly one NUL directly to the log FIFO each interval:

```bash
printf '\0' >&"${log_fd}"
```

The collector performs one steady-state operation per marker:

```bash
log_chunks=()
mapfile -d '' -t -n 1 -u "${log_fd}" log_chunks
log_chunk=${log_chunks[0]-}
```

`-d ''` selects NUL, `-t` removes the delimiter, `-n 1` returns after one delimiter-terminated item, and `-u` selects the FIFO descriptor. One item is the complete interval batch before the NUL; embedded newlines and backslashes remain ordinary content. `-n 1` is required because the FIFO remains open and an unbounded `mapfile` could wait indefinitely for EOF. Bash variables cannot contain NUL, so the marker is written directly rather than stored or scanned for.

## Producers and atomicity

Ordinary file-log production remains the original single raw write:

```bash
printf '%s' "${msg}" >&"${log_fd}"
```

No per-record header, framing, delimiter, padding block, intermediary process, parser, or producer-side length calculation is added.

Concurrent raw producer records continue to rely on the pre-existing Linux pipe-write atomicity assumption that each formatted record fits within `PIPE_BUF`. No universal source-level maximum exists because some records include dynamically sized or user-controlled values. This PR leaves that existing producer behaviour unchanged; atomic-record hardening belongs in a separate change with separate producer benchmarking.

Direct stdout redirected to `log_fd` is expected to remain textual. External output containing NUL would violate the interval-marker protocol.

## Removed configuration option

This design has no size-triggered steady-state completion, so the formerly active `log_file_buffer_size_B` option has been intentionally removed. Users with an override such as:

```bash
log_file_buffer_size_B=512
```

must delete it. Existing validation rejects the obsolete entry with the normal “not a valid config entry” error; removing it restores successful validation. The original implementation’s former 512-byte default is used only as the benchmark baseline. The candidate has no corresponding size setting.

### Minimum buffering interval

`log_file_buffer_timeout_ms` now has a minimum of 50 ms. A zero interval would cause the NUL waker and collector to loop continuously, while excessively short intervals would undermine the intended CPU reduction. The default remains 500 ms.

## Collector behavior

For each completed interval, `mapfile` consumes all real bytes before the marker. A non-empty batch is written once; a marker-only interval performs no file write. Only real bytes contribute to `log_file_size_bytes`, and rotation and signal checks run after empty and non-empty intervals. An unexpected `mapfile` failure with no item and no pending signal reports an error and exits rather than retrying in a CPU-burning loop.

## Exceptional drain

Rotation, export, reset, and shutdown use a short timed exceptional drain:

```bash
IFS= read -r -d '' -t 0.01 -u "${log_fd}" log_chunk
```

It consumes complete NUL-delimited batches, processes final partial data even when timed `read` returns nonzero, consumes queued markers, skips delimiter-only batches and never stores a marker in output. This timed read is not used for steady-state collection.

## Shutdown ordering

A collector blocked in untimed `mapfile` releases itself from its inline `TERM` trap:

```bash
trap 'signal+=KILL; printf "\0" >&"${log_fd}"' TERM
```

Cleanup proceeds as follows:

1. `terminate` sends one `TERM` to `maintain_log_file`;
2. the collector trap appends `KILL` and writes one NUL;
3. blocked `mapfile` consumes the marker and returns;
4. real data before the marker is written exactly once;
5. signal handling sees `KILL`, performs the exceptional drain and exits;
6. `terminate` completes its bounded wait;
7. cleanup terminates `log_file_waker` afterward.

Only `TERM` emits the marker; the separate `EXIT` trap records `KILL` without writing one. Release is independent of whether the waker remains alive.

## Correctness results

A controlled integration harness loaded the production logger functions and compared exact bytes for time- and size-based rotation; USR1 export; USR2 reset; uncompressed and gzip exports; normal shutdown; pending partial shutdown; blocked-mapfile shutdown; shutdown after unexpected waker exit; repeated `TERM`; queued markers; embedded newlines and backslashes; more than 8192 real bytes in one interval; textual stdout redirected to `log_fd`; and unexpected `mapfile` failure without a busy loop.

The size test measured 13 bytes of overshoot from a 23-byte interval against a 10-byte threshold. Byte scans proved that no NUL reached active, rotated, uncompressed-exported, or decompressed-exported output. Configuration tests confirmed that the default configuration validates, an obsolete `log_file_buffer_size_B` override is rejected, and removing it restores validation.

These tests establish that the optimization preserves existing behavior; they are not the motivation for the change.

The candidate was also installed using `setup.sh` and smoke-tested on an OpenWrt router with its real CAKE interfaces, `tc`, pingers and SUMMARY logging. The service operated normally and restarted successfully after allowing sufficient initialization time. Total observed cake-autorate CPU hovered around 9%, compared with approximately 10% for the previous implementation. This is a live-router observation rather than a controlled benchmark.

## Preliminary OpenWrt performance evidence

The quick OpenWrt run used three measured 30-second repetitions and raw `/proc/<pid>/stat` clock ticks. Every completed run passed exact-output validation.

| Workload | Variant | Producer | Collector | Waker | Logger total | Combined |
|---|---|---:|---:|---:|---:|---:|
| SUMMARY 20/s | Original 512-byte timed read | 31 | 17 | 0 | 17 | 48 |
| SUMMARY 20/s | `read -d ''` | 31 | 11 | 2 | 13 | 44 |
| SUMMARY 20/s | `mapfile -d '' -n 1` | 31 | 11 | 2 | 13 | 44 |
| SUMMARY 20/s | Bounded NUL read | 30 | 13 | 2 | 15 | 45 |
| SUMMARY+DATA 20 pairs/s | Original 512-byte timed read | 52 | 54 | 0 | 54 | 106 |
| SUMMARY+DATA 20 pairs/s | `read -d ''` | 52 | 32 | 2 | 34 | 86 |
| SUMMARY+DATA 20 pairs/s | `mapfile -d '' -n 1` | 51 | 29 | 2 | 31 | 82 |
| SUMMARY+DATA 20 pairs/s | Bounded NUL read | 52 | 41 | 2 | 43 | 95 |

“Logger total” means collector plus waker. For SUMMARY+DATA, collector observations were original 54/54/55, `read -d ''` 32/33/33, and mapfile 29/30/29 ticks.

The mapfile medians represent 23.5% less logger CPU and 8.3% less combined benchmark-process CPU for SUMMARY, and 42.6% less logger CPU and 22.6% less combined benchmark-process CPU for SUMMARY+DATA. These are not reductions in total cake-autorate CPU. Idle observations of one to three ticks are inconclusive. A longer standard OpenWrt run remains outstanding.

Mapfile was selected because it directly expresses one item per interval, tied the unbounded NUL read for SUMMARY, and had the lowest preliminary SUMMARY+DATA collector and combined measurements. The bounded comparator retains extra size-triggered wakeups that this design intentionally removes.

## Latency and rotation tradeoff

The original returns at approximately 512 bytes or timeout; this candidate returns at the next periodic marker.

| Workload | Original 512-byte reader | NUL/mapfile batching |
|---|---:|---:|
| Sparse data | Up to about 500 ms | Up to about 500 ms |
| SUMMARY at 20/s | About 251 ms maximum, 125 ms average | About 500 ms maximum, 250 ms average |
| SUMMARY+DATA at 20 pairs/s | About 76 ms maximum, 38 ms average | About 500 ms maximum, 250 ms average |

Sparse maximum delay remains approximately 500 ms by default, but active-log file visibility is slower. Rotation and signal observation have the same interval granularity, and size rotation may overshoot by up to one interval’s real data. This affects buffered-file visibility, not reflector processing, pingers, `main_fd`, the control loop, `fsync`, or physical-storage durability.

## Static analysis

`bash -n`, committed-range whitespace checks, and the repository-wide removal check passed. `shellcheck cake-autorate.sh` and `shellcheck -x cake-autorate.sh` also completed successfully with no warning- or error-severity findings; both reported only the same three informational SC2310 diagnostics about functions invoked in conditional contexts.

## Prior experiments and remaining work

Prior experiments are [#414 — framed](https://github.com/lynxthecat/cake-autorate/pull/414) and [#415 — fixed padding](https://github.com/lynxthecat/cake-autorate/pull/415). Neither closed PR is modified.

A longer standard OpenWrt benchmark also remains desirable as follow-up work for more precise performance evidence, but it is not a correctness or merge blocker given the controlled lifecycle tests, preliminary three-repetition measurements and completed live-router smoke test. The candidate has been confirmed against current master.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a92a29ab6d4832ea63b2de63c5b9b74)

