### PR TITLE
Optimize pinger response parsing hot path

### DIFF
--- a/benchmarks/benchmark-pinger-response-read.sh
+++ b/benchmarks/benchmark-pinger-response-read.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Microbenchmark only: this does not measure whole-program cake-autorate CPU use.
+set -u
+iterations=${1:-200000}
+method=${2:-fping}
+case $method in
+	irtt) line='1720000000000000 1.1.1.1 7 1200 2300' ;;
+	tsping) line='1720000000.123456 1.1.1.1 8 a b c d e 1.25 2.50' ;;
+	fping) line='[1720000000.12345] 1.1.1.1 : [9] 64 bytes 12.3 ms ttl 57 x z' ;;
+	fping-ts) line='[1720000000.12345] 1.1.1.1 : [10] 64 bytes 4.0 ms ttl 57 x y z Originate=100 Receive=101 Transmit=102 Localreceive=103' ;;
+	ping) line='[1720000000.123456] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 time=8.4 ms' ;;
+	*) printf 'unknown method: %s\n' "$method" >&2; exit 2 ;;
+esac
+
+input=$(mktemp)
+trap 'rm -f "$input"' EXIT
+for ((i=0; i<iterations; i++)); do printf '%s\n' "$line"; done > "$input"
+
+old()
+{
+	local i timestamp reflector seq rtt_ms dl ul originate received transmit finished
+	local fd
+	local -a command
+	exec {fd}< "$input"
+	for ((i=0; i<iterations; i++)); do
+		read -r -u "$fd" -a command
+		case $method in
+			irtt) timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl=${command[3]} ul=${command[4]} ;;
+			tsping) timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl=${command[8]} ul=${command[9]} ;;
+			fping) timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} rtt_ms=${command[6]} ;;
+			fping-ts) timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} originate=${command[13]#Originate=}000 received=${command[14]#Receive=}000 transmit=${command[15]#Transmit=}000 finished=${command[16]#Localreceive=}000 ;;
+			ping) timestamp=${command[0]} reflector=${command[4]%:} seq=${command[5]} rtt_ms=${command[7]} ;;
+		esac
+	done
+	exec {fd}<&-
+}
+new()
+{
+	local i timestamp reflector seq dl ul rtt_ms originate received transmit finished unexpected
+	local field1 field2 field3 field4 field5 field6 field7 field8 field9 field10 field11 field12 fd
+	exec {fd}< "$input"
+	for ((i=0; i<iterations; i++)); do
+		case $method in
+			irtt) read -r -u "$fd" timestamp reflector seq dl ul unexpected ;;
+			tsping) read -r -u "$fd" timestamp reflector seq field3 field4 field5 field6 field7 dl ul unexpected ;;
+			fping) read -r -u "$fd" timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected ;;
+			fping-ts) read -r -u "$fd" timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected ; originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000 ;;
+			ping) read -r -u "$fd" timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected; reflector=${reflector%:} ;;
+		esac
+	done
+	exec {fd}<&-
+}
+printf '%s (%d responses)\n' "$method" "$iterations"
+printf 'old: '; time old
+printf 'new: '; time new

--- a/benchmarks/benchmark-pinger-response-read.sh
+++ b/benchmarks/benchmark-pinger-response-read.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Microbenchmark only: this does not measure whole-program cake-autorate CPU use.
+# Parsing microbenchmark only; this does not measure whole-program CPU use.
 set -u
-iterations=${1:-200000}
+iterations=${1:-500000}
 method=${2:-fping}
 case $method in
 	irtt) line='1720000000000000 1.1.1.1 7 1200 2300' ;;
@@ -11,45 +11,72 @@ case $method in
 	ping) line='[1720000000.123456] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 time=8.4 ms' ;;
 	*) printf 'unknown method: %s\n' "$method" >&2; exit 2 ;;
 esac
-
 input=$(mktemp)
 trap 'rm -f "$input"' EXIT
 for ((i=0; i<iterations; i++)); do printf '%s\n' "$line"; done > "$input"
 
-old()
+master()
 {
-	local i timestamp reflector seq rtt_ms dl ul originate received transmit finished
-	local fd
+	local i fd timestamp timestamp_us reflector seq rtt_ms rtt_us dl ul originate received transmit finished reflector_response
 	local -a command
 	exec {fd}< "$input"
 	for ((i=0; i<iterations; i++)); do
+		reflector_response=0
 		read -r -u "$fd" -a command
 		case $method in
-			irtt) timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl=${command[3]} ul=${command[4]} ;;
-			tsping) timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl=${command[8]} ul=${command[9]} ;;
-			fping) timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} rtt_ms=${command[6]} ;;
-			fping-ts) timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} originate=${command[13]#Originate=}000 received=${command[14]#Receive=}000 transmit=${command[15]#Transmit=}000 finished=${command[16]#Localreceive=}000 ;;
-			ping) timestamp=${command[0]} reflector=${command[4]%:} seq=${command[5]} rtt_ms=${command[7]} ;;
+			irtt) if ((${#command[@]} == 5)); then timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl=${command[3]} ul=${command[4]} timestamp_us=${command[0]} reflector_response=1; fi ;;
+			tsping) if ((${#command[@]} == 10)); then timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl=${command[8]}000 ul=${command[9]}000 timestamp_us=${command[0]//[.]} reflector_response=1; fi ;;
+			fping) if ((${#command[@]} == 12)) && [[ ${command[6]} != *[!0-9.]* ]]; then timestamp=${command[0]} reflector=${command[1]} seq=${command[3]#[}; seq=${seq%]}; rtt_ms=${command[6]}; printf -v rtt_us %.3f "$rtt_ms"; ((dl=10#${rtt_us//.}/2, ul=dl)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}0; reflector_response=1; fi ;;
+			fping-ts) if ((${#command[@]} == 17)); then timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} originate=${command[13]#Originate=}000 received=${command[14]#Receive=}000 transmit=${command[15]#Transmit=}000 finished=${command[16]#Localreceive=}000; seq=${seq#[}; seq=${seq%]}; ((dl=finished-transmit, ul=received-originate)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}0; reflector_response=1; fi ;;
+			ping) if ((${#command[@]} == 9)) && [[ ${command[7]} == time=* ]]; then timestamp=${command[0]} reflector=${command[4]%:} seq=${command[5]} rtt_ms=${command[7]//time=}; seq=${seq//icmp_seq=}; printf -v rtt_us %.3f "$rtt_ms"; ((dl=10#${rtt_us//.}/2, ul=dl)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}; reflector_response=1; fi ;;
 		esac
 	done
 	exec {fd}<&-
 }
-new()
+
+pr417()
 {
-	local i timestamp reflector seq dl ul rtt_ms originate received transmit finished unexpected
-	local field1 field2 field3 field4 field5 field6 field7 field8 field9 field10 field11 field12 fd
+	local i fd timestamp timestamp_us reflector seq dl ul rtt_ms rtt_us originate received transmit finished unexpected reflector_response
+	local field1 field2 field3 field4 field5 field6 field7 field8 field9 field10 field11 field12
 	exec {fd}< "$input"
 	for ((i=0; i<iterations; i++)); do
+		reflector_response=0
 		case $method in
 			irtt) read -r -u "$fd" timestamp reflector seq dl ul unexpected ;;
 			tsping) read -r -u "$fd" timestamp reflector seq field3 field4 field5 field6 field7 dl ul unexpected ;;
 			fping) read -r -u "$fd" timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected ;;
-			fping-ts) read -r -u "$fd" timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected ; originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000 ;;
-			ping) read -r -u "$fd" timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected; reflector=${reflector%:} ;;
+			fping-ts) read -r -u "$fd" timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected ;;
+			ping) read -r -u "$fd" timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected ;;
+		esac
+		case $method in
+			irtt) [[ -n $ul && -z $unexpected ]] && timestamp_us=$timestamp && reflector_response=1 ;;
+			tsping) [[ -n $ul && -z $unexpected ]] && dl=${dl}000 && ul=${ul}000 && timestamp_us=${timestamp//[.]} && reflector_response=1 ;;
+			fping) if [[ -n $field11 && -z $unexpected && $rtt_ms != *[!0-9.]* ]]; then seq=${seq#[}; seq=${seq%]}; printf -v rtt_us %.3f "$rtt_ms"; ((dl=10#${rtt_us//.}/2, ul=dl)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}0; reflector_response=1; fi ;;
+			fping-ts) if [[ -n $finished && -z $unexpected ]]; then originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000; seq=${seq#[}; seq=${seq%]}; ((dl=finished-transmit, ul=received-originate)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}0; reflector_response=1; fi ;;
+			ping) if [[ -n $field8 && -z $unexpected && $rtt_ms == time=* ]]; then reflector=${reflector%:}; seq=${seq//icmp_seq=}; rtt_ms=${rtt_ms//time=}; printf -v rtt_us %.3f "$rtt_ms"; ((dl=10#${rtt_us//.}/2, ul=dl)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}; reflector_response=1; fi ;;
+		esac
+	done
+	exec {fd}<&-
+}
+
+refined()
+{
+	local i fd timestamp timestamp_us reflector seq dl ul rtt_ms rtt_us originate received transmit finished unexpected reflector_response
+	local field1 field2 field3 field4 field5 field6 field7 field8 field9 field10 field11 field12
+	exec {fd}< "$input"
+	for ((i=0; i<iterations; i++)); do
+		reflector_response=0
+		case $method in
+			irtt) read -r -u "$fd" timestamp reflector seq dl ul unexpected; [[ -n $ul && -z $unexpected ]] && timestamp_us=$timestamp && reflector_response=1 ;;
+			tsping) read -r -u "$fd" timestamp reflector seq field3 field4 field5 field6 field7 dl ul unexpected; [[ -n $ul && -z $unexpected ]] && dl=${dl}000 && ul=${ul}000 && timestamp_us=${timestamp//[.]} && reflector_response=1 ;;
+			fping) read -r -u "$fd" timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected; if [[ -n $field11 && -z $unexpected && $rtt_ms != *[!0-9.]* ]]; then seq=${seq#[}; seq=${seq%]}; printf -v rtt_us %.3f "$rtt_ms"; ((dl=10#${rtt_us//.}/2, ul=dl)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}0; reflector_response=1; fi ;;
+			fping-ts) read -r -u "$fd" timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected; if [[ -n $finished && -z $unexpected ]]; then originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000; seq=${seq#[}; seq=${seq%]}; ((dl=finished-transmit, ul=received-originate)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}0; reflector_response=1; fi ;;
+			ping) read -r -u "$fd" timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected; if [[ -n $field8 && -z $unexpected && $rtt_ms == time=* ]]; then reflector=${reflector%:}; seq=${seq//icmp_seq=}; rtt_ms=${rtt_ms//time=}; printf -v rtt_us %.3f "$rtt_ms"; ((dl=10#${rtt_us//.}/2, ul=dl)); timestamp_us=${timestamp#[}; timestamp_us=${timestamp_us%]}; timestamp_us=${timestamp_us//.}; reflector_response=1; fi ;;
 		esac
 	done
 	exec {fd}<&-
 }
 printf '%s (%d responses)\n' "$method" "$iterations"
-printf 'old: '; time old
-printf 'new: '; time new
+printf 'master:  '; time master
+printf 'PR #417: '; time pr417
+printf 'refined:  '; time refined

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1110,6 +1110,23 @@ case ${pinger_method} in
 		;;
 esac
 
+# Record where a three-field SARS message lands in each direct-read layout.
+# These variable names are resolved indirectly only on the cold SARS path.
+case ${pinger_method} in
+	irtt)
+		sars_dl_var=reflector sars_ul_var=seq sars_overflow_var=dl_owd_us
+		;;
+	tsping)
+		sars_dl_var=reflector sars_ul_var=seq sars_overflow_var=field3
+		;;
+	fping|fping-ts)
+		sars_dl_var=reflector sars_ul_var=field2 sars_overflow_var=seq
+		;;
+	ping)
+		sars_dl_var=field1 sars_ul_var=field2 sars_overflow_var=field3
+		;;
+esac
+
 (( no_pingers < 1 )) && { log_msg "ERROR" "number of pingers must be at least 1. Exiting script."; exit 1; }
 (( no_pingers > no_reflectors )) && { log_msg "ERROR" "number of pingers cannot be greater than number of reflectors. Exiting script."; exit 1; }
 
@@ -1422,18 +1439,51 @@ do
 	case ${pinger_method} in
 		irtt)
 			read -r -u "${main_fd}" timestamp reflector seq dl_owd_us ul_owd_us unexpected
+			if [[ ${timestamp} != SARS && -n ${ul_owd_us} && -z ${unexpected} ]]
+			then
+				timestamp_us=${timestamp} reflector_response=1
+			fi
 			;;
 		tsping)
 			read -r -u "${main_fd}" timestamp reflector seq field3 field4 field5 field6 field7 dl_owd_ms ul_owd_ms unexpected
+			if [[ ${timestamp} != SARS && -n ${ul_owd_ms} && -z ${unexpected} ]]
+			then
+				dl_owd_us=${dl_owd_ms}000 ul_owd_us=${ul_owd_ms}000
+				timestamp_us=${timestamp//[.]} reflector_response=1
+			fi
 			;;
 		fping)
 			read -r -u "${main_fd}" timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected
+			if [[ ${timestamp} != SARS && -n ${field11} && -z ${unexpected} && ${rtt_ms} != *[!0-9.]* ]]
+			then
+				seq=${seq#[} seq=${seq%]}
+				printf -v rtt_us %.3f "${rtt_ms}"
+				((dl_owd_us=10#${rtt_us//.}/2, ul_owd_us=dl_owd_us))
+				timestamp_us=${timestamp#[} timestamp_us=${timestamp_us%]}
+				timestamp_us=${timestamp_us//.}0 reflector_response=1
+			fi
 			;;
 		fping-ts)
 			read -r -u "${main_fd}" timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected
+			if [[ ${timestamp} != SARS && -n ${finished} && -z ${unexpected} ]]
+			then
+				seq=${seq#[} seq=${seq%]}
+				originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000
+				((dl_owd_us=finished-transmit, ul_owd_us=received-originate))
+				timestamp_us=${timestamp#[} timestamp_us=${timestamp_us%]}
+				timestamp_us=${timestamp_us//.}0 reflector_response=1
+			fi
 			;;
 		ping)
 			read -r -u "${main_fd}" timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected
+			if [[ ${timestamp} != SARS && -n ${field8} && -z ${unexpected} && ${rtt_ms} == time=* ]]
+			then
+				reflector=${reflector%:} seq=${seq//icmp_seq=} rtt_ms=${rtt_ms//time=}
+				printf -v rtt_us %.3f "${rtt_ms}"
+				((dl_owd_us=10#${rtt_us//.}/2, ul_owd_us=dl_owd_us))
+				timestamp_us=${timestamp#[} timestamp_us=${timestamp_us%]}
+				timestamp_us=${timestamp_us//.} reflector_response=1
+			fi
 			;;
 		*)
 			log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
@@ -1442,107 +1492,46 @@ do
 	esac
 	[[ -n ${timestamp} ]] || continue
 
-	case ${timestamp} in
+	# Set download and upload achieved rates. The indirect expansions use the
+	# field layout selected once during initialization.
+	if [[ ${timestamp} == SARS ]]
+	then
+		achieved_dl_rate_kbps=${!sars_dl_var} achieved_ul_rate_kbps=${!sars_ul_var}
+		if [[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${!sars_overflow_var} ]]
+		then
+			achieved_rate_kbps[DL]=${achieved_dl_rate_kbps} achieved_rate_kbps[UL]=${achieved_ul_rate_kbps} achieved_rate_updated[DL]=1 achieved_rate_updated[UL]=1
+			((
+				load_percent[DL]=100*achieved_rate_kbps[DL]/shaper_rate_kbps[DL],
+				load_percent[UL]=100*achieved_rate_kbps[UL]/shaper_rate_kbps[UL]
+			))
 
-		# Set download and upload achieved rates
-		SARS)
-			sars_response=0
-			case ${pinger_method} in
-				irtt)
-					achieved_dl_rate_kbps=${reflector} achieved_ul_rate_kbps=${seq}
-					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${dl_owd_us}${unexpected} ]] && sars_response=1
-					;;
-				tsping)
-					achieved_dl_rate_kbps=${reflector} achieved_ul_rate_kbps=${seq}
-					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${field3}${unexpected} ]] && sars_response=1
-					;;
-				fping|fping-ts)
-					achieved_dl_rate_kbps=${reflector} achieved_ul_rate_kbps=${field2}
-					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${seq}${unexpected} ]] && sars_response=1
-					;;
-				ping)
-					achieved_dl_rate_kbps=${field1} achieved_ul_rate_kbps=${field2}
-					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${field3}${unexpected} ]] && sars_response=1
-					;;
-				*)
-					;;
-			esac
-			if ((sars_response))
+			if ((output_load_stats))
 			then
-				achieved_rate_kbps[DL]=${achieved_dl_rate_kbps} achieved_rate_kbps[UL]=${achieved_ul_rate_kbps} achieved_rate_updated[DL]=1 achieved_rate_updated[UL]=1
-				((
-					load_percent[DL]=100*achieved_rate_kbps[DL]/shaper_rate_kbps[DL],
-					load_percent[UL]=100*achieved_rate_kbps[UL]/shaper_rate_kbps[UL]
-				))
-
-				if ((output_load_stats))
-				then
-					printf -v load_stats '%s; %s; %s; %s; %s' "${EPOCHREALTIME}" "${achieved_rate_kbps[DL]}" "${achieved_rate_kbps[UL]}" "${shaper_rate_kbps[DL]}" "${shaper_rate_kbps[UL]}"
-					log_msg "LOAD" "${load_stats}"
-				fi
-
-				if (( load_percent[DL] > high_load_thr_percent ))
-				then
-					load_state[DL]=${LOAD_HIGH}
-				elif (( achieved_rate_kbps[DL] > connection_active_thr_kbps ))
-				then
-					load_state[DL]=${LOAD_LOW}
-				else
-					load_state[DL]=${LOAD_IDLE}
-				fi
-
-				if (( load_percent[UL] > high_load_thr_percent ))
-				then
-					load_state[UL]=${LOAD_HIGH}
-				elif (( achieved_rate_kbps[UL] > connection_active_thr_kbps ))
-				then
-					load_state[UL]=${LOAD_LOW}
-				else
-					load_state[UL]=${LOAD_IDLE}
-				fi
+				printf -v load_stats '%s; %s; %s; %s; %s' "${EPOCHREALTIME}" "${achieved_rate_kbps[DL]}" "${achieved_rate_kbps[UL]}" "${shaper_rate_kbps[DL]}" "${shaper_rate_kbps[UL]}"
+				log_msg "LOAD" "${load_stats}"
 			fi
-			;;
-		*)
-			case "${pinger_method}" in
 
-				irtt)
-					if [[ -n ${ul_owd_us} && -z ${unexpected} ]]
-					then
-						reflector_response=1
-					fi
-					;;
-				tsping)
-					if [[ -n ${ul_owd_ms} && -z ${unexpected} ]]
-					then
-						reflector_response=1
-					fi
-					;;
-				fping)
-					if [[ -n ${field11} && -z ${unexpected} && ${rtt_ms} != *[!0-9.]* ]]
-					then
-						reflector_response=1
-					fi
-					;;
-				fping-ts)
-					if [[ -n ${finished} && -z ${unexpected} ]]
-					then
-						originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000 reflector_response=1
-					fi
-					;;
-				ping)
-					if [[ -n ${field8} && -z ${unexpected} && ${rtt_ms} == time=* ]]
-					then
-						reflector=${reflector%:} reflector_response=1
-					fi
-					;;
-				*)
-					log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
-					kill $$ 2>/dev/null
-				;;
-			esac
-			;;
-	esac
+			if (( load_percent[DL] > high_load_thr_percent ))
+			then
+				load_state[DL]=${LOAD_HIGH}
+			elif (( achieved_rate_kbps[DL] > connection_active_thr_kbps ))
+			then
+				load_state[DL]=${LOAD_LOW}
+			else
+				load_state[DL]=${LOAD_IDLE}
+			fi
 
+			if (( load_percent[UL] > high_load_thr_percent ))
+			then
+				load_state[UL]=${LOAD_HIGH}
+			elif (( achieved_rate_kbps[UL] > connection_active_thr_kbps ))
+			then
+				load_state[UL]=${LOAD_LOW}
+			else
+				load_state[UL]=${LOAD_IDLE}
+			fi
+		fi
+	fi
 	t_start_us=${EPOCHREALTIME/.}
 	if ((reflector_response))
 	then
@@ -1598,12 +1587,8 @@ do
 							))
 						fi
 						
-						timestamp_us=${timestamp}
-						
 						;;
 					tsping)
-						dl_owd_us=${dl_owd_ms}000 ul_owd_us=${ul_owd_ms}000
-
 						((
 							dl_owd_delta_us=dl_owd_us - dl_owd_baselines_us[pinger],
 							ul_owd_delta_us=ul_owd_us - ul_owd_baselines_us[pinger]
@@ -1635,16 +1620,9 @@ do
 							))
 						fi
 
-						timestamp_us=${timestamp//[.]}
-
 						;;
 					fping)
-						seq=${seq#[} seq=${seq%]}
-						printf -v rtt_us %.3f "${rtt_ms}"
-
 						((
-							dl_owd_us=10#${rtt_us//.}/2,
-							ul_owd_us=dl_owd_us,
 							dl_alpha = dl_owd_us >= dl_owd_baselines_us[pinger] ? alpha_baseline_increase : alpha_baseline_decrease,
 
 							dl_owd_baselines_us[pinger]=(dl_alpha*dl_owd_us+(1000000-dl_alpha)*dl_owd_baselines_us[pinger])/1000000,
@@ -1661,18 +1639,11 @@ do
 								ul_owd_delta_ewmas_us[pinger]=dl_owd_delta_ewmas_us[pinger]
 							))
 						fi
-
-						timestamp_us=${timestamp#[} timestamp_us=${timestamp_us%]}
-						timestamp_us=${timestamp_us//.}0
 
 						;;
 
 					fping-ts)
-						seq=${seq#[} seq=${seq%]}
-
 						((
-							dl_owd_us=finished-transmit,
-							ul_owd_us=received-originate,
 							dl_owd_delta_us=dl_owd_us - dl_owd_baselines_us[pinger],
 							ul_owd_delta_us=ul_owd_us - ul_owd_baselines_us[pinger]
 						))
@@ -1702,19 +1673,9 @@ do
 							))
 						fi
 
-						timestamp_us=${timestamp#[} timestamp_us=${timestamp_us%]}
-						timestamp_us=${timestamp_us//.}0
-
 						;;
 					ping)
-						seq=${seq//icmp_seq=} rtt_ms=${rtt_ms//time=}
-
-						printf -v rtt_us %.3f "${rtt_ms}"
-
 						((
-							dl_owd_us=10#${rtt_us//.}/2,
-							ul_owd_us=dl_owd_us,
-
 							dl_alpha = dl_owd_us >= dl_owd_baselines_us[pinger] ? alpha_baseline_increase : alpha_baseline_decrease,
 
 							dl_owd_baselines_us[pinger]=(dl_alpha*dl_owd_us+(1000000-dl_alpha)*dl_owd_baselines_us[pinger])/1000000,
@@ -1731,9 +1692,6 @@ do
 								ul_owd_delta_ewmas_us[pinger]=dl_owd_delta_ewmas_us[pinger]
 							))
 						fi
-
-						timestamp_us=${timestamp#[} timestamp_us=${timestamp_us%]}
-						timestamp_us=${timestamp_us//.}
 
 						;;
 					*)

--- a/cake-autorate.sh
+++ b/cake-autorate.sh
@@ -1411,18 +1411,65 @@ log_msg "INFO" "Started cake-autorate with PID: ${BASHPID} and config: ${config_
 
 while :
 do
-	unset command
 	reflector_response=0
-	read -r -u "${main_fd}" -a command
-	((${#command[@]})) || continue
 
-	case ${command[0]} in
+	# Read pinger output directly into the fields used below.  The extra final
+	# variable is intentional: read assigns all surplus words to its last
+	# variable, allowing the exact field counts accepted by the former array
+	# parser to be preserved.
+	# Placeholder fields enforce those counts.
+	# shellcheck disable=SC2034
+	case ${pinger_method} in
+		irtt)
+			read -r -u "${main_fd}" timestamp reflector seq dl_owd_us ul_owd_us unexpected
+			;;
+		tsping)
+			read -r -u "${main_fd}" timestamp reflector seq field3 field4 field5 field6 field7 dl_owd_ms ul_owd_ms unexpected
+			;;
+		fping)
+			read -r -u "${main_fd}" timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected
+			;;
+		fping-ts)
+			read -r -u "${main_fd}" timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected
+			;;
+		ping)
+			read -r -u "${main_fd}" timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected
+			;;
+		*)
+			log_msg "ERROR" "Unknown pinger method: ${pinger_method}"
+			kill $$ 2>/dev/null
+			;;
+	esac
+	[[ -n ${timestamp} ]] || continue
+
+	case ${timestamp} in
 
 		# Set download and upload achieved rates
 		SARS)
-			if ((${#command[@]} == 3))
+			sars_response=0
+			case ${pinger_method} in
+				irtt)
+					achieved_dl_rate_kbps=${reflector} achieved_ul_rate_kbps=${seq}
+					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${dl_owd_us}${unexpected} ]] && sars_response=1
+					;;
+				tsping)
+					achieved_dl_rate_kbps=${reflector} achieved_ul_rate_kbps=${seq}
+					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${field3}${unexpected} ]] && sars_response=1
+					;;
+				fping|fping-ts)
+					achieved_dl_rate_kbps=${reflector} achieved_ul_rate_kbps=${field2}
+					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${seq}${unexpected} ]] && sars_response=1
+					;;
+				ping)
+					achieved_dl_rate_kbps=${field1} achieved_ul_rate_kbps=${field2}
+					[[ -n ${achieved_dl_rate_kbps} && -n ${achieved_ul_rate_kbps} && -z ${field3}${unexpected} ]] && sars_response=1
+					;;
+				*)
+					;;
+			esac
+			if ((sars_response))
 			then
-				achieved_rate_kbps[DL]=${command[1]} achieved_rate_kbps[UL]=${command[2]} achieved_rate_updated[DL]=1 achieved_rate_updated[UL]=1
+				achieved_rate_kbps[DL]=${achieved_dl_rate_kbps} achieved_rate_kbps[UL]=${achieved_ul_rate_kbps} achieved_rate_updated[DL]=1 achieved_rate_updated[UL]=1
 				((
 					load_percent[DL]=100*achieved_rate_kbps[DL]/shaper_rate_kbps[DL],
 					load_percent[UL]=100*achieved_rate_kbps[UL]/shaper_rate_kbps[UL]
@@ -1459,33 +1506,33 @@ do
 			case "${pinger_method}" in
 
 				irtt)
-					if ((${#command[@]} == 5))
+					if [[ -n ${ul_owd_us} && -z ${unexpected} ]]
 					then
-						timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl_owd_us=${command[3]} ul_owd_us=${command[4]} reflector_response=1
+						reflector_response=1
 					fi
 					;;
 				tsping)
-					if ((${#command[@]} == 10))
+					if [[ -n ${ul_owd_ms} && -z ${unexpected} ]]
 					then
-						timestamp=${command[0]} reflector=${command[1]} seq=${command[2]} dl_owd_ms=${command[8]} ul_owd_ms=${command[9]} reflector_response=1
+						reflector_response=1
 					fi
 					;;
 				fping)
-					if ((${#command[@]} == 12)) && [[ ${command[6]} != *[!0-9.]* ]]
+					if [[ -n ${field11} && -z ${unexpected} && ${rtt_ms} != *[!0-9.]* ]]
 					then
-						timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} rtt_ms=${command[6]} reflector_response=1
+						reflector_response=1
 					fi
 					;;
 				fping-ts)
-					if ((${#command[@]} == 17))
+					if [[ -n ${finished} && -z ${unexpected} ]]
 					then
-						timestamp=${command[0]} reflector=${command[1]} seq=${command[3]} originate=${command[13]#Originate=}000 received=${command[14]#Receive=}000 transmit=${command[15]#Transmit=}000 finished=${command[16]#Localreceive=}000 reflector_response=1
+						originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000 reflector_response=1
 					fi
 					;;
 				ping)
-					if ((${#command[@]} == 9)) && [[ ${command[7]} == time=* ]]
+					if [[ -n ${field8} && -z ${unexpected} && ${rtt_ms} == time=* ]]
 					then
-						timestamp=${command[0]} reflector=${command[4]%:} seq=${command[5]} rtt_ms=${command[7]} reflector_response=1
+						reflector=${reflector%:} reflector_response=1
 					fi
 					;;
 				*)

--- a/tests/test-pinger-response-read.sh
+++ b/tests/test-pinger-response-read.sh
@@ -4,34 +4,52 @@ set -u
 parse()
 {
 	local method=$1 line=$2 timestamp reflector seq dl_owd_us ul_owd_us unexpected
-	local dl_owd_ms ul_owd_ms rtt_ms originate received transmit finished
+	local dl_owd_ms ul_owd_ms rtt_ms originate received transmit finished reflector_response=0
 	local field1 field2 field3 field4 field5 field6 field7 field8 field9 field10 field11 field12
+	local sars_dl_var sars_ul_var sars_overflow_var
 	case $method in
-		irtt) read -r timestamp reflector seq dl_owd_us ul_owd_us unexpected <<< "$line" ;;
-		tsping) read -r timestamp reflector seq field3 field4 field5 field6 field7 dl_owd_ms ul_owd_ms unexpected <<< "$line" ;;
-		fping) read -r timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected <<< "$line" ;;
-		fping-ts) read -r timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected <<< "$line" ;;
-		ping) read -r timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected <<< "$line" ;;
+		irtt) sars_dl_var=reflector sars_ul_var=seq sars_overflow_var=dl_owd_us ;;
+		tsping) sars_dl_var=reflector sars_ul_var=seq sars_overflow_var=field3 ;;
+		fping|fping-ts) sars_dl_var=reflector sars_ul_var=field2 sars_overflow_var=seq ;;
+		ping) sars_dl_var=field1 sars_ul_var=field2 sars_overflow_var=field3 ;;
+	esac
+
+	case $method in
+		irtt)
+			read -r timestamp reflector seq dl_owd_us ul_owd_us unexpected <<< "$line"
+			[[ $timestamp != SARS && -n $ul_owd_us && -z $unexpected ]] && reflector_response=1
+			;;
+		tsping)
+			read -r timestamp reflector seq field3 field4 field5 field6 field7 dl_owd_ms ul_owd_ms unexpected <<< "$line"
+			[[ $timestamp != SARS && -n $ul_owd_ms && -z $unexpected ]] && reflector_response=1
+			;;
+		fping)
+			read -r timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected <<< "$line"
+			if [[ $timestamp != SARS && -n $field11 && -z $unexpected && $rtt_ms != *[!0-9.]* ]]; then seq=${seq#[}; seq=${seq%]}; reflector_response=1; fi
+			;;
+		fping-ts)
+			read -r timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected <<< "$line"
+			if [[ $timestamp != SARS && -n $finished && -z $unexpected ]]; then seq=${seq#[}; seq=${seq%]}; originate=${originate#Originate=}000 received=${received#Receive=}000 transmit=${transmit#Transmit=}000 finished=${finished#Localreceive=}000 reflector_response=1; fi
+			;;
+		ping)
+			read -r timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected <<< "$line"
+			if [[ $timestamp != SARS && -n $field8 && -z $unexpected && $rtt_ms == time=* ]]; then reflector=${reflector%:}; seq=${seq//icmp_seq=}; rtt_ms=${rtt_ms//time=}; reflector_response=1; fi
+			;;
 	esac
 
 	[[ -n $timestamp ]] || { printf empty; return; }
 	if [[ $timestamp == SARS ]]
 	then
-		case $method in
-			irtt) [[ -n $reflector && -n $seq && -z $dl_owd_us$unexpected ]] && printf 'sars:%s:%s' "$reflector" "$seq" || printf malformed ;;
-			tsping) [[ -n $reflector && -n $seq && -z $field3$unexpected ]] && printf 'sars:%s:%s' "$reflector" "$seq" || printf malformed ;;
-			fping|fping-ts) [[ -n $reflector && -n $field2 && -z $seq$unexpected ]] && printf 'sars:%s:%s' "$reflector" "$field2" || printf malformed ;;
-			ping) [[ -n $field1 && -n $field2 && -z $field3$unexpected ]] && printf 'sars:%s:%s' "$field1" "$field2" || printf malformed ;;
-		esac
+		if [[ -n ${!sars_dl_var} && -n ${!sars_ul_var} && -z ${!sars_overflow_var} ]]; then printf 'sars:%s:%s' "${!sars_dl_var}" "${!sars_ul_var}"; else printf malformed; fi
 		return
 	fi
-
+	((reflector_response)) || { printf malformed; return; }
 	case $method in
-		irtt) [[ -n $ul_owd_us && -z $unexpected ]] && printf 'ping:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$dl_owd_us" "$ul_owd_us" || printf malformed ;;
-		tsping) [[ -n $ul_owd_ms && -z $unexpected ]] && printf 'ping:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$dl_owd_ms" "$ul_owd_ms" || printf malformed ;;
-		fping) [[ -n $field11 && -z $unexpected && $rtt_ms != *[!0-9.]* ]] && printf 'ping:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$rtt_ms" || printf malformed ;;
-		fping-ts) [[ -n $finished && -z $unexpected ]] && printf 'ping:%s:%s:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "${originate#Originate=}000" "${received#Receive=}000" "${transmit#Transmit=}000" "${finished#Localreceive=}000" || printf malformed ;;
-		ping) [[ -n $field8 && -z $unexpected && $rtt_ms == time=* ]] && printf 'ping:%s:%s:%s:%s' "$timestamp" "${reflector%:}" "$seq" "$rtt_ms" || printf malformed ;;
+		irtt) printf 'ping:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$dl_owd_us" "$ul_owd_us" ;;
+		tsping) printf 'ping:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$dl_owd_ms" "$ul_owd_ms" ;;
+		fping) printf 'ping:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$rtt_ms" ;;
+		fping-ts) printf 'ping:%s:%s:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$originate" "$received" "$transmit" "$finished" ;;
+		ping) printf 'ping:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$rtt_ms" ;;
 	esac
 }
 
@@ -44,9 +62,9 @@ check()
 
 check 'ping:1720000000000000:1.1.1.1:7:1200:2300' irtt '1720000000000000 1.1.1.1 7 1200 2300'
 check 'ping:1720000000.123456:1.1.1.1:8:1.25:2.50' tsping '1720000000.123456 1.1.1.1 8 a b c d e 1.25 2.50'
-check 'ping:[1720000000.12345]:1.1.1.1:[9]:12.3' fping '[1720000000.12345] 1.1.1.1 : [9] 64 bytes 12.3 ms ttl 57 x z'
-check 'ping:[1720000000.12345]:1.1.1.1:[10]:100000:101000:102000:103000' fping-ts '[1720000000.12345] 1.1.1.1 : [10] 64 bytes 4.0 ms ttl 57 x y z Originate=100 Receive=101 Transmit=102 Localreceive=103'
-check 'ping:[1720000000.123456]:1.1.1.1:icmp_seq=11:time=8.4' ping '[1720000000.123456] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 time=8.4 ms'
+check 'ping:[1720000000.12345]:1.1.1.1:9:12.3' fping '[1720000000.12345] 1.1.1.1 : [9] 64 bytes 12.3 ms ttl 57 x z'
+check 'ping:[1720000000.12345]:1.1.1.1:10:100000:101000:102000:103000' fping-ts '[1720000000.12345] 1.1.1.1 : [10] 64 bytes 4.0 ms ttl 57 x y z Originate=100 Receive=101 Transmit=102 Localreceive=103'
+check 'ping:[1720000000.123456]:1.1.1.1:11:8.4' ping '[1720000000.123456] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 time=8.4 ms'
 
 for method in irtt tsping fping fping-ts ping; do
 	check 'sars:123:456' "$method" 'SARS 123 456'

--- a/tests/test-pinger-response-read.sh
+++ b/tests/test-pinger-response-read.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -u
+
+parse()
+{
+	local method=$1 line=$2 timestamp reflector seq dl_owd_us ul_owd_us unexpected
+	local dl_owd_ms ul_owd_ms rtt_ms originate received transmit finished
+	local field1 field2 field3 field4 field5 field6 field7 field8 field9 field10 field11 field12
+	case $method in
+		irtt) read -r timestamp reflector seq dl_owd_us ul_owd_us unexpected <<< "$line" ;;
+		tsping) read -r timestamp reflector seq field3 field4 field5 field6 field7 dl_owd_ms ul_owd_ms unexpected <<< "$line" ;;
+		fping) read -r timestamp reflector field2 seq field4 field5 rtt_ms field7 field8 field9 field10 field11 unexpected <<< "$line" ;;
+		fping-ts) read -r timestamp reflector field2 seq field4 field5 field6 field7 field8 field9 field10 field11 field12 originate received transmit finished unexpected <<< "$line" ;;
+		ping) read -r timestamp field1 field2 field3 reflector seq field6 rtt_ms field8 unexpected <<< "$line" ;;
+	esac
+
+	[[ -n $timestamp ]] || { printf empty; return; }
+	if [[ $timestamp == SARS ]]
+	then
+		case $method in
+			irtt) [[ -n $reflector && -n $seq && -z $dl_owd_us$unexpected ]] && printf 'sars:%s:%s' "$reflector" "$seq" || printf malformed ;;
+			tsping) [[ -n $reflector && -n $seq && -z $field3$unexpected ]] && printf 'sars:%s:%s' "$reflector" "$seq" || printf malformed ;;
+			fping|fping-ts) [[ -n $reflector && -n $field2 && -z $seq$unexpected ]] && printf 'sars:%s:%s' "$reflector" "$field2" || printf malformed ;;
+			ping) [[ -n $field1 && -n $field2 && -z $field3$unexpected ]] && printf 'sars:%s:%s' "$field1" "$field2" || printf malformed ;;
+		esac
+		return
+	fi
+
+	case $method in
+		irtt) [[ -n $ul_owd_us && -z $unexpected ]] && printf 'ping:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$dl_owd_us" "$ul_owd_us" || printf malformed ;;
+		tsping) [[ -n $ul_owd_ms && -z $unexpected ]] && printf 'ping:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$dl_owd_ms" "$ul_owd_ms" || printf malformed ;;
+		fping) [[ -n $field11 && -z $unexpected && $rtt_ms != *[!0-9.]* ]] && printf 'ping:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "$rtt_ms" || printf malformed ;;
+		fping-ts) [[ -n $finished && -z $unexpected ]] && printf 'ping:%s:%s:%s:%s:%s:%s:%s' "$timestamp" "$reflector" "$seq" "${originate#Originate=}000" "${received#Receive=}000" "${transmit#Transmit=}000" "${finished#Localreceive=}000" || printf malformed ;;
+		ping) [[ -n $field8 && -z $unexpected && $rtt_ms == time=* ]] && printf 'ping:%s:%s:%s:%s' "$timestamp" "${reflector%:}" "$seq" "$rtt_ms" || printf malformed ;;
+	esac
+}
+
+check()
+{
+	local expected=$1 method=$2 line=$3 actual
+	actual=$(parse "$method" "$line")
+	if [[ $actual != "$expected" ]]; then printf 'FAIL %s\n expected: %s\n actual:   %s\n' "$method: $line" "$expected" "$actual" >&2; exit 1; fi
+}
+
+check 'ping:1720000000000000:1.1.1.1:7:1200:2300' irtt '1720000000000000 1.1.1.1 7 1200 2300'
+check 'ping:1720000000.123456:1.1.1.1:8:1.25:2.50' tsping '1720000000.123456 1.1.1.1 8 a b c d e 1.25 2.50'
+check 'ping:[1720000000.12345]:1.1.1.1:[9]:12.3' fping '[1720000000.12345] 1.1.1.1 : [9] 64 bytes 12.3 ms ttl 57 x z'
+check 'ping:[1720000000.12345]:1.1.1.1:[10]:100000:101000:102000:103000' fping-ts '[1720000000.12345] 1.1.1.1 : [10] 64 bytes 4.0 ms ttl 57 x y z Originate=100 Receive=101 Transmit=102 Localreceive=103'
+check 'ping:[1720000000.123456]:1.1.1.1:icmp_seq=11:time=8.4' ping '[1720000000.123456] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 time=8.4 ms'
+
+for method in irtt tsping fping fping-ts ping; do
+	check 'sars:123:456' "$method" 'SARS 123 456'
+	check malformed "$method" 'SARS 123'
+	check malformed "$method" 'SARS 123 456 extra'
+done
+
+check malformed irtt '1720000000000000 1.1.1.1 7 1200'
+check malformed irtt '1720000000000000 1.1.1.1 7 1200 2300 extra'
+check malformed tsping '1720000000.123456 1.1.1.1 8 a b c d e 1.25'
+check malformed tsping '1720000000.123456 1.1.1.1 8 a b c d e 1.25 2.50 extra'
+check malformed fping '[1] 1.1.1.1 : [9] 64 bytes timeout ms ttl 57 x z'
+check malformed fping '[1] 1.1.1.1 : [9] 64 bytes 1.0 ms ttl 57 x'
+check malformed fping '[1] 1.1.1.1 : [9] 64 bytes 1.0 ms ttl 57 x z extra'
+check malformed fping-ts '[1] 1.1.1.1 : [10] 64 bytes 4 ms ttl 57 x y z Originate=100 Receive=101 Transmit=102'
+check malformed fping-ts '[1] 1.1.1.1 : [10] 64 bytes 4 ms ttl 57 x y z Originate=100 Receive=101 Transmit=102 Localreceive=103 extra'
+check malformed ping '[1] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 timeout ms'
+check malformed ping '[1] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 time=8.4'
+check malformed ping '[1] 64 bytes from 1.1.1.1: icmp_seq=11 ttl=57 time=8.4 ms extra'
+printf 'All pinger-response read tests passed.\n'


### PR DESCRIPTION
## Motivation

The main loop previously read every `main_fd` message with `read -a command`, allocated/populated an array, then copied selected array elements into the scalar values actually used by the pinger processing. That work occurs for every pinger response on constrained routers.

## Implementation

- Keeps the existing single blocking `main_fd`, so either pinger output or a SARS achieved-rate update wakes the main loop.
- Reads each pinger format directly into its downstream scalar fields, avoiding `command[]` creation, array indexing, and remapping.
- Keeps each method's direct read, exact-count/format validation, and syntax-level extraction/conversion together in one `pinger_method` case. The later method case now contains only the existing RTT/OWD baseline algorithms that require a resolved pinger index.
- Configures three SARS layout variable names once during startup: the scalar receiving download rate, upload rate, and a fourth word. The cold SARS branch resolves those names with Bash indirect expansion and is therefore generic rather than dispatching on `pinger_method` again.
- Uses the last expected pinger field plus a final `unexpected` destination to preserve exact pinger field counts under Bash `read` semantics. SARS accepts only non-empty rate fields and an empty fourth-field destination, rejecting both short and overlong messages.
- Removes the redundant `unset command`; the optimized path no longer creates that array (and `read -a` cleared it itself previously).

No extra FD, producer normalization, polling, subprocess, or external command was added to the runtime parsing path.

## Parsing-only benchmark

`benchmarks/benchmark-pinger-response-read.sh 100000 METHOD` prepares representative input outside the timed region, then reads it through a file descriptor. It compares:

A. master (`read -a` plus remapping and extraction);
B. the initial PR #417 direct-read implementation with separate read and validation dispatches; and
C. the refined direct-read implementation with one parsing dispatch.

CPU time below is `user + sys` from one 100,000-response development-container run:

| Method | Master | Initial PR #417 | Refined | Refined vs master | Refined vs initial PR |
|---|---:|---:|---:|---:|---:|
| irtt | 2.261 s | 1.721 s | 1.625 s | 28.1% faster | 5.6% faster |
| tsping | 2.841 s | 2.735 s | 2.607 s | 8.2% faster | 4.7% faster |
| fping | 4.872 s | 4.748 s | 4.445 s | 8.8% faster | 6.4% faster |
| fping-ts | 6.668 s | 5.923 s | 5.652 s | 15.2% faster | 4.6% faster |
| ping | 5.163 s | 5.046 s | 4.645 s | 10.0% faster | 7.9% faster |

The target OpenWrt measurements supplied for the initial implementation remain useful context: five 500,000-response fping runs averaged about 92.27 s on master and 83.49 s on the initial PR, a 9.5% parsing CPU reduction. The refined benchmark remains no slower in the development measurements, but target hardware should be treated as authoritative.

These are deliberately **parsing-only microbenchmarks**, not claims that cake-autorate's whole-program CPU usage falls by the same percentages.

## Validation

- `tests/test-pinger-response-read.sh`
- `bash -n ./*.sh tests/*.sh benchmarks/*.sh`
- `shellcheck --severity=error cake-autorate.sh tests/test-pinger-response-read.sh benchmarks/benchmark-pinger-response-read.sh`
- `git diff --check`
- all three benchmark variants for irtt, tsping, fping, fping-ts, and ping

Focused tests cover valid responses for all five methods; valid SARS under every layout; short and overlong SARS; short and overlong pinger output; and the existing fping and ping format checks.
